### PR TITLE
Mine positives online

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A contrastive, self-supervised method for learning textual representations.
 
 ## Installation
 
-This repository required Python 3.7 or later.
+This repository requires Python 3.7 or later.
 
 ### Setting up a virtual environment
 
@@ -16,18 +16,18 @@ Before installing, you should create and activate a Python virtual environment. 
 
 First, clone the repository locally
 
-```
+```bash
 git clone https://github.com/JohnGiorgi/t2t.git
 ```
 
 Then, install
 
-```
+```bash
 cd t2t
 pip install --editable .
 ```
 
-For the time being, please install [AllenNLP](https://github.com/allenai/allennlp) [from source](https://github.com/allenai/allennlp#installing-from-source). You should also install [PyTorch](https://pytorch.org/) with [CUDA](https://developer.nvidia.com/cuda-zone) support by following the instructions for your system [here](https://pytorch.org/get-started/locally/).
+> For the time being, please install [AllenNLP](https://github.com/allenai/allennlp) [from source](https://github.com/allenai/allennlp#installing-from-source). You should also install [PyTorch](https://pytorch.org/) with [CUDA](https://developer.nvidia.com/cuda-zone) support by following the instructions for your system [here](https://pytorch.org/get-started/locally/).
 
 ## Usage
 
@@ -39,7 +39,7 @@ Datasets should be text files where each line contains a raw text sequence. You 
 
 To train the model, run the following command
 
-```
+```bash
 allennlp train contrastive.jsonnet -s tmp --include-package t2t
 ```
 
@@ -47,23 +47,15 @@ During training, models, vocabulary, configuration and log files will be saved t
 
 ### Embedding
 
-To embed text with a trained model, you first need a copy of the config used to train the model, where `training = false`. Specifically, you need to:
+To embed text with a trained model, run the following command
 
-1. Copy the config used to train the model (in our example, this would be `tmp/config.json`). E.g., `cp tmp/config.json tmp/config_embed.json`.
-2. In the copied config, set `training = false`.
-3. Include the flag `--overrides` in your call to `allennlp predict`, providing it the path to the modified config.
-
-Then run the following command
-
-```
+```bash
 allennlp predict tmp path/to/input.txt \
  --output-file tmp/embeddings.jsonl \
- --weights-file tmp/best.th \
  --batch-size 32 \
  --cuda-device 0 \
  --use-dataset-reader \
- --dataset-reader-choice validation \
- --overrides tmp/config_embed.json \
+ --overrides '{"dataset_reader.sample_spans": false}' \
  --include-package t2t
 ```
 
@@ -74,3 +66,13 @@ This will:
 3. Save the embeddings to disk as a [JSON lines](http://jsonlines.org/) file (`tmp/embeddings.jsonl`)
 
 The text embeddings are stored in the field `"embeddings"` in `tmp/embeddings.jsonl`.
+
+#### Embedding without the projection head
+
+[Previous work](https://arxiv.org/abs/2002.05709) has found that the representations learned by the encoder network outperform those learned by the projection head for downstream tasks. To discard the projection head when embedding text, add  `{"model.feedforward": null}` to the `--overrides` argument of `allennlp predict`, e.g.
+
+```bash
+--overrides '{"dataset_reader.sample_spans": false, "model.feedforward": null}'
+```
+
+This will embed the input text using _only_ the encoder network. These embeddings _may_ perform better on downstream tasks.

--- a/README.md
+++ b/README.md
@@ -67,12 +67,4 @@ This will:
 
 The text embeddings are stored in the field `"embeddings"` in `tmp/embeddings.jsonl`.
 
-#### Embedding without the projection head
-
-[Previous work](https://arxiv.org/abs/2002.05709) has found that the representations learned by the encoder network outperform those learned by the projection head for downstream tasks. To discard the projection head when embedding text, add  `{"model.feedforward": null}` to the `--overrides` argument of `allennlp predict`, e.g.
-
-```bash
---overrides '{"dataset_reader.sample_spans": false, "model.feedforward": null}'
-```
-
-This will embed the input text using _only_ the encoder network. These embeddings _may_ perform better on downstream tasks.
+> If your model was trained with a `FeedForward` module, it will also contain a field named `"projections"`. A `FeedForward` module with a non-linear transformation [may improve the quality of representations learned by the encoder network](https://arxiv.org/abs/2002.05709).

--- a/README.md
+++ b/README.md
@@ -47,7 +47,13 @@ During training, models, vocabulary, configuration and log files will be saved t
 
 ### Embedding
 
-To embed text with a trained model, run the following command
+To embed text with a trained model, you first need a copy of the config used to train the model, where `training = false`. Specifically, you need to:
+
+1. Copy the config used to train the model (in our example, this would be `tmp/config.json`). E.g., `cp tmp/config.json tmp/config_embed.json`.
+2. In the copied config, set `training = false`.
+3. Include the flag `--overrides` in your call to `allennlp predict`, providing it the path to the modified config.
+
+Then run the following command
 
 ```
 allennlp predict tmp path/to/input.txt \
@@ -57,6 +63,7 @@ allennlp predict tmp path/to/input.txt \
  --cuda-device 0 \
  --use-dataset-reader \
  --dataset-reader-choice validation \
+ --overrides tmp/config_embed.json \
  --include-package t2t
 ```
 
@@ -66,14 +73,4 @@ This will:
 2. Use that model to embed the text in the provided input file (`path/to/input.txt`).
 3. Save the embeddings to disk as a [JSON lines](http://jsonlines.org/) file (`tmp/embeddings.jsonl`)
 
-The text embeddings are stored in the field `"embeddings"` in `embeddings.jsonl`.
-
-#### Embedding without the projection head
-
-Previous work has found that the representations learned by encoder network outperform those learned by the projection head for downstream tasks. To discard the projection head when embedding text, you will need to:
-
-1. Copy the config used to train the model (in our example, this would be `tmp/config.json`).
-2. Remove the `"FeedForward"` field from this copy of the config.
-3. Include the flag `--overrides` in your call to `allennlp predict`, providing it the path to the modified config.
-
-This will embed the input text using _only_ the encoder network. These embeddings _may_ perform better on downstream tasks.
+The text embeddings are stored in the field `"embeddings"` in `tmp/embeddings.jsonl`.

--- a/t2t/data/dataset_readers/contrastive.py
+++ b/t2t/data/dataset_readers/contrastive.py
@@ -1,15 +1,16 @@
-import csv
 import logging
-from typing import Dict, Optional
+from typing import Dict, Iterable, List, Optional
 
 from overrides import overrides
 
 from allennlp.common.file_utils import cached_path
 from allennlp.data.dataset_readers import DatasetReader
-from allennlp.data.fields import TextField
+from allennlp.data.fields import Field, ListField, TextField
 from allennlp.data.instance import Instance
 from allennlp.data.token_indexers import SingleIdTokenIndexer, TokenIndexer
 from allennlp.data.tokenizers import SpacyTokenizer, Tokenizer
+from t2t.data.dataset_readers.dataset_utils.span_utils import extract_spans
+from allennlp.common.checks import ConfigurationError
 
 logger = logging.getLogger(__name__)
 
@@ -17,67 +18,81 @@ logger = logging.getLogger(__name__)
 @DatasetReader.register("contrastive")
 class ContrastiveDatasetReader(DatasetReader):
     """
+    Read a txt file containing one instance per line, and create a dataset suitable for a `ContrastiveTextEncoder`
+    model.
+
+    The output of `read` is a list of `Instance` s with the field:
+        tokens : `ListField[TextField]`
+
+    # Parameters
+
+    tokenizer : `Tokenizer`, optional (default = `{"tokens": SpacyTokenizer()}`)
+        Tokenizer to use to split the input text into words or other kinds of tokens.
+    token_indexers : `Dict[str, TokenIndexer]`, optional
+        optional (default=`{"tokens": SingleIdTokenIndexer()}`)
+        We use this to define the input representation for the text.
+        See :class:`TokenIndexer`.
+    max_spans : ``int``, optional (default = None)
+        The total number of spans to return. Defaults to returning all possible spans.
+    min_span_width : `int`, optional (default = 1)
+        The minimum length of spans which should be included. Defaults to 1.
     """
 
     def __init__(
         self,
         tokenizer: Tokenizer = None,
         token_indexers: Dict[str, TokenIndexer] = None,
-        delimiter: str = "\t",
-        max_tokens: Optional[int] = None,
+        extract_spans: bool = True,
+        min_span_width: int = 1,
+        max_spans: Optional[int] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self._tokenizer = tokenizer or SpacyTokenizer()
         self._token_indexers = token_indexers or {"tokens": SingleIdTokenIndexer()}
-        self._delimiter = delimiter
-        self._max_tokens = max_tokens
-        self._anchor_max_exceeded = 0
-        self._positive_max_exceeded = 0
+        self._extract_spans = extract_spans
+        self._max_spans = max_spans
+        self._min_span_width = min_span_width
 
     @overrides
-    def _read(self, file_path: str):
-        # Reset exceeded counts
-        self._anchor_max_exceeded = 0
-        self._positive_max_exceeded = 0
+    def _read(self, file_path: str) -> Iterable[Instance]:
         with open(cached_path(file_path), "r") as data_file:
             logger.info("Reading instances from lines in file at: %s", file_path)
-            for row in csv.reader(data_file, delimiter=self._delimiter):
-                # A positive sequence will only be provided when training
-                if len(row) == 2:
-                    anchor_sequence, positive_sequence = row
-                else:
-                    anchor_sequence, positive_sequence = row, None
-                yield self.text_to_instance(anchor_sequence, positive_sequence)
-        if self._max_tokens and self._anchor_max_exceeded:
-            logger.info(
-                "In %d instances, the anchor token length exceeded the max limit (%d) and were truncated.",
-                self._anchor_max_exceeded,
-                self._max_tokens,
-            )
-        if self._max_tokens and self._positive_max_exceeded:
-            logger.info(
-                "In %d instances, the positive token length exceeded the max limit (%d) and were truncated.",
-                self._positive_max_exceeded,
-                self.max_tokens,
-            )
+            for line_num, text in enumerate(data_file):
+                # We use whitespace tokenization when sampling spans, so we also use it here to check that a
+                # valid min_span_width was given.
+                num_tokens = len(text.split())
+                if num_tokens < self._min_span_width:
+                    raise ConfigurationError(
+                        f"min_span_width is {self._min_span_width} but instance on line {line_num} has len {num_tokens}"
+                    )
+                yield self.text_to_instance(text)
 
     @overrides
-    def text_to_instance(
-        self, anchor_string: str, positive_string: str = None
-    ) -> Instance:  # type: ignore
+    def text_to_instance(self, text: str) -> Instance:  # type: ignore
+        """
+        # Parameters
 
-        tokenized_anchor = self._tokenizer.tokenize(anchor_string)
-        if self._max_tokens and len(tokenized_anchor) > self._max_tokens:
-            self._anchor_max_exceeded += 1
-            tokenized_anchor = tokenized_anchor[: self._max_tokens]
-        anchor_field = TextField(tokenized_anchor, self._token_indexers)
-        if positive_string is not None:
-            tokenized_positive = self._tokenizer.tokenize(positive_string)
-            if self._max_tokens and len(tokenized_positive) > self._max_tokens:
-                self._positive_max_exceeded += 1
-                tokenized_positive = tokenized_positive[: self._max_tokens]
-            positive_field = TextField(tokenized_positive, self._token_indexers)
-            return Instance({"anchor_tokens": anchor_field, "positive_tokens": positive_field})
+        text : `str`, required.
+            The text to process.
+
+        # Returns
+
+        An `Instance` containing the following fields:
+            tokens : ``Union[TextField, ListField[TextField]]`
+                If `self._extract_spans`, returns a `ListField` containing `self._max_spans` number of random,
+                tokenized spans from `text`.
+                Else, returns a `TextField` containing tokenzied `text`.
+        """
+
+        fields: Dict[str, Field] = {}
+        if self._extract_spans:
+            spans: List[Field] = []
+            for span in extract_spans(text, self._max_spans, min_span_width=self._min_span_width):
+                tokens = self._tokenizer.tokenize(span)
+                spans.append(TextField(tokens, self._token_indexers))
+            fields["tokens"] = ListField(spans)
         else:
-            return Instance({"anchor_tokens": anchor_field})
+            tokens = self._tokenizer.tokenize(text)
+            fields["tokens"] = TextField(tokens, self._token_indexers)
+        return Instance(fields)

--- a/t2t/data/dataset_readers/contrastive.py
+++ b/t2t/data/dataset_readers/contrastive.py
@@ -3,14 +3,14 @@ from typing import Dict, Iterable, List, Optional
 
 from overrides import overrides
 
+from allennlp.common.checks import ConfigurationError
 from allennlp.common.file_utils import cached_path
 from allennlp.data.dataset_readers import DatasetReader
 from allennlp.data.fields import Field, ListField, TextField
 from allennlp.data.instance import Instance
 from allennlp.data.token_indexers import SingleIdTokenIndexer, TokenIndexer
 from allennlp.data.tokenizers import SpacyTokenizer, Tokenizer
-from t2t.data.dataset_readers.dataset_utils.span_utils import extract_spans
-from allennlp.common.checks import ConfigurationError
+from t2t.data.dataset_readers.dataset_utils.span_utils import sample_spans
 
 logger = logging.getLogger(__name__)
 
@@ -28,21 +28,23 @@ class ContrastiveDatasetReader(DatasetReader):
 
     tokenizer : `Tokenizer`, optional (default = `{"tokens": SpacyTokenizer()}`)
         Tokenizer to use to split the input text into words or other kinds of tokens.
-    token_indexers : `Dict[str, TokenIndexer]`, optional
-        optional (default=`{"tokens": SingleIdTokenIndexer()}`)
-        We use this to define the input representation for the text.
-        See :class:`TokenIndexer`.
+    token_indexers : `Dict[str, TokenIndexer]`, optional (default=`{"tokens": SingleIdTokenIndexer()}`)
+        We use this to define the input representation for the text. See :class:`TokenIndexer`.
+    sample_spans : ``boolean``, optional (default = True)
+        If True, spans of text will be sampled from each input, tokenized and indexed.
     max_spans : ``int``, optional (default = None)
-        The total number of spans to return. Defaults to returning all possible spans.
+        The total number of spans to sample for each input. Defaults to sampling all possible spans. Has no
+        effect if `sample_spans` is `False`.
     min_span_width : `int`, optional (default = 1)
-        The minimum length of spans which should be included. Defaults to 1.
+        The minimum length of spans which should be sampled. Defaults to 1. Has no effect if `sample_spans` is
+        `False`.
     """
 
     def __init__(
         self,
         tokenizer: Tokenizer = None,
         token_indexers: Dict[str, TokenIndexer] = None,
-        extract_spans: bool = True,
+        sample_spans: bool = True,
         min_span_width: int = 1,
         max_spans: Optional[int] = None,
         **kwargs,
@@ -50,7 +52,7 @@ class ContrastiveDatasetReader(DatasetReader):
         super().__init__(**kwargs)
         self._tokenizer = tokenizer or SpacyTokenizer()
         self._token_indexers = token_indexers or {"tokens": SingleIdTokenIndexer()}
-        self._extract_spans = extract_spans
+        self._sample_spans = sample_spans
         self._max_spans = max_spans
         self._min_span_width = min_span_width
 
@@ -64,7 +66,8 @@ class ContrastiveDatasetReader(DatasetReader):
                 num_tokens = len(text.split())
                 if num_tokens < self._min_span_width:
                     raise ConfigurationError(
-                        f"min_span_width is {self._min_span_width} but instance on line {line_num} has len {num_tokens}"
+                        (f"min_span_width is {self._min_span_width} but instance on line {line_num + 1} has len"
+                         f" {num_tokens}")
                     )
                 yield self.text_to_instance(text)
 
@@ -80,15 +83,15 @@ class ContrastiveDatasetReader(DatasetReader):
 
         An `Instance` containing the following fields:
             tokens : ``Union[TextField, ListField[TextField]]`
-                If `self._extract_spans`, returns a `ListField` containing `self._max_spans` number of random,
+                If `self._sample_spans`, returns a `ListField` containing `self._max_spans` number of random,
                 tokenized spans from `text`.
-                Else, returns a `TextField` containing tokenzied `text`.
+                Else, returns a `TextField` containing tokenized `text`.
         """
 
         fields: Dict[str, Field] = {}
-        if self._extract_spans:
+        if self._sample_spans:
             spans: List[Field] = []
-            for span in extract_spans(text, self._max_spans, min_span_width=self._min_span_width):
+            for span in sample_spans(text, self._max_spans, min_span_width=self._min_span_width):
                 tokens = self._tokenizer.tokenize(span)
                 spans.append(TextField(tokens, self._token_indexers))
             fields["tokens"] = ListField(spans)

--- a/t2t/data/dataset_readers/dataset_utils/span_utils.py
+++ b/t2t/data/dataset_readers/dataset_utils/span_utils.py
@@ -1,0 +1,30 @@
+from typing import Iterable, Optional
+
+import numpy as np
+
+from allennlp.data.dataset_readers.dataset_utils.span_utils import \
+    enumerate_spans
+
+
+def sample_spans(text: str, max_spans: Optional[int] = None, **kwargs) -> Iterable[str]:
+    """Returns a generator that yields random spans from `text`.
+
+    # Parameters
+
+    text : ``str``, required.
+        The string to extract spans from.
+    max_spans : ``int``, optional (default = None)
+        The total number of spans to return. Defaults to returning all possible spans.
+    **kwargs : ``Dict``
+        Additional keyword arguments to be passed to `enumerate_spans`.
+    """
+    # No need for fancier tokenization here. Whitespace tokenization will suffice to generate spans.
+    tokens = text.split()
+    span_indices = enumerate_spans(tokens, **kwargs)
+    np.random.shuffle(span_indices)
+    if max_spans is not None:
+        span_indices = span_indices[:max_spans]
+
+    for start, end in span_indices:
+        # Add 1 to end index because spans from enumerate_spans are inclusive.
+        yield " ".join(tokens[start: end + 1])

--- a/t2t/models/contrastive_text_encoder.py
+++ b/t2t/models/contrastive_text_encoder.py
@@ -25,8 +25,6 @@ class ContrastiveTextEncoder(Model):
     # Parameters
 
     vocab : `Vocabulary`
-    temperature : `float`
-        Required temperature hyperparameter for the `NTXentLoss` function.
     text_field_embedder : `TextFieldEmbedder`
         Used to embed the input text into a `TextField`
     seq2seq_encoder : `Seq2SeqEncoder`, optional, (default=`None`)
@@ -44,7 +42,6 @@ class ContrastiveTextEncoder(Model):
     def __init__(
         self,
         vocab: Vocabulary,
-        temperature: float,
         text_field_embedder: TextFieldEmbedder,
         seq2vec_encoder: Seq2VecEncoder,
         seq2seq_encoder: Optional[Seq2SeqEncoder] = None,
@@ -65,7 +62,7 @@ class ContrastiveTextEncoder(Model):
         self._feedforward = feedforward
 
         # TODO (John): Any way we can "register" this so it can be created "from_params"?
-        self._loss = NTXentLoss(temperature)
+        self._loss = NTXentLoss(kwargs['temperature'])
         initializer(self)
 
     def forward(  # type: ignore

--- a/t2t/models/util.py
+++ b/t2t/models/util.py
@@ -1,6 +1,9 @@
+import random
 from typing import Tuple
 
 import torch
+
+from allennlp.data import TextFieldTensors
 
 
 def format_embed_pt_metric_loss(
@@ -31,3 +34,47 @@ def format_embed_pt_metric_loss(
     labels = torch.cat((indices, indices))
 
     return embeddings, labels
+
+
+def sample_anchor_positive_pairs(tokens) -> Tuple[TextFieldTensors, TextFieldTensors]:
+    """Returns a tuple of `TextFieldTensors` containing random batches of anchors and positives from tokens.
+
+    # Parameters
+
+    tokens : TextFieldTensors
+        From a `TextField`
+    """
+    # The procedure for sampling anchor, positive pairs is as follows:
+    #   1. Sample two random spans for every training instance
+    #   2. Unpack the TextFieldTensors, extract the token ids, masks, and type ids for the sampled pairs
+    #   3. Repackage the information into TextFieldTensors
+    num_spans = tokens["tokens"]["token_ids"].size(1)
+    index = torch.as_tensor(
+        random.sample(range(0, num_spans), 2),
+        device=tokens["tokens"]["token_ids"].device
+    )
+
+    random_token_ids = torch.index_select(tokens["tokens"]["token_ids"], dim=1, index=index)
+    random_masks = torch.index_select(tokens["tokens"]["mask"], dim=1, index=index)
+    random_type_ids = torch.index_select(tokens["tokens"]["type_ids"], dim=1, index=index)
+
+    anchor_token_ids, positive_token_ids = torch.chunk(random_token_ids, 2, dim=1)
+    anchor_masks, positive_masks = torch.chunk(random_masks, 2, dim=1)
+    anchor_type_ids, positive_type_ids = torch.chunk(random_type_ids, 2, dim=1)
+
+    anchors: TextFieldTensors = {
+        "tokens": {
+            "token_ids": anchor_token_ids.squeeze(1),
+            "mask": anchor_masks.squeeze(1),
+            "type_ids": anchor_type_ids.squeeze(1)
+        }
+    }
+    positives: TextFieldTensors = {
+        "tokens": {
+            "token_ids": positive_token_ids.squeeze(1),
+            "mask": positive_masks.squeeze(1),
+            "type_ids": positive_type_ids.squeeze(1)
+        }
+    }
+
+    return anchors, positives


### PR DESCRIPTION
# Overview

This PR moves the mining of positives "online". This is opposed to making this a separate, "offline" step that the user would be expected to perform. There are a few advantages to this:

- A user no longer needs to do any processing. We simply need a text file, containing one instance per line.
- It is easier to assign multiple positives to each anchor and to assign a different positive (or set of positives) to each anchor across epochs. Previously, (anchor, positive) pairs were totally static.
- Applying transformations to the positives (e.g. Round-Trip Translation, RTT) will now be much more straightforward.

This was achieved pretty easily. Namely, I:

1. Wrote a custom dataloader that accepts a text file, with one instance per line. For each instance we extract a number of random spans. These are tokenized, indexed, and returned as an `Instance` containing a `ListField` of `TextField` s.

2. In the forward pass of the model, we select two random spans from each `Instance`. These form the anchors and the positives.

## Other changes

- Makes it much easier to change between training and testing modes. Just set `training = true` or `training = false` in the config.

## TODOs

- [ ] Speed up extraction of spans.
- [ ] Figure out how to delete unused tensors in `foward`.
- [ ] Do we need to partition the loss into two parts? (e.g. L = l_i_j + l_j_i).

## Closes

Closes #27.