### PR TITLE
Add SentEval benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,27 @@ This will:
 The text embeddings are stored in the field `"embeddings"` in `tmp/embeddings.jsonl`.
 
 > If your model was trained with a `FeedForward` module, it will also contain a field named `"projections"`. A `FeedForward` module with a non-linear transformation [may improve the quality of representations learned by the encoder network](https://arxiv.org/abs/2002.05709).
+
+### Evaluating with SentEval
+
+[SentEval](https://github.com/facebookresearch/SentEval) is a library for evaluating the quality of sentence embeddings. To evaluate the quality of the embeddings learned by our model, you need to do two things:
+
+Clone the SentEval repository and download the transfer task datasets
+
+```bash
+git clone https://github.com/facebookresearch/SentEval.git
+cd SentEval/data/downstream/
+./get_transfer_data.bash
+```
+
+> See the SentEval repository for full details.
+
+Set the relevant paths at the top of `scripts/run_senteval_benchmark.py`, then call
+
+```bash
+python scripts/run_senteval_benchmark.py
+```
+
+The results will be logged to the console.
+
+> This is a work in progress, I hope to make this much more user-friendly in the coming weeks.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ cd SentEval/data/downstream/
 
 > See the SentEval repository for full details.
 
-Then you can run our helper script to evaluate a trained model against SentEval
+Then you can run our [script](scripts/run_senteval_benchmark.py) to evaluate a trained model against SentEval
 
 ```bash
 python scripts/run_senteval_benchmark.py SentEval tmp \

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ The text embeddings are stored in the field `"embeddings"` in `tmp/embeddings.js
 
 ### Evaluating with SentEval
 
-[SentEval](https://github.com/facebookresearch/SentEval) is a library for evaluating the quality of sentence embeddings. To evaluate the quality of the embeddings learned by our model, you need to do two things:
+[SentEval](https://github.com/facebookresearch/SentEval) is a library for evaluating the quality of sentence embeddings. We provide a script to easily evaluate our model against SentEval.
 
-Clone the SentEval repository and download the transfer task datasets
+First, clone the SentEval repository and download the transfer task datasets (you only need to do this once)
 
 ```bash
 git clone https://github.com/facebookresearch/SentEval.git
@@ -83,12 +83,17 @@ cd SentEval/data/downstream/
 
 > See the SentEval repository for full details.
 
-Set the relevant paths at the top of `scripts/run_senteval_benchmark.py`, then call
+Then you can run our helper script to evaluate a trained model against SentEval
 
 ```bash
-python scripts/run_senteval_benchmark.py
+python scripts/run_senteval_benchmark.py SentEval tmp \
+ --cuda-device 0 \
+ --overrides '{"dataset_reader.sample_spans": false}' \
+ --include-package t2t
 ```
 
-The results will be logged to the console.
+The results will be logged to the console. For more options, run
 
-> This is a work in progress, I hope to make this much more user-friendly in the coming weeks.
+```bash
+python scripts/run_senteval_benchmark.py --help
+```

--- a/contrastive.jsonnet
+++ b/contrastive.jsonnet
@@ -60,7 +60,7 @@ local token_embedding_size = 768;
     "iterator": {
         "type": "basic",
         // TODO (John): Ideally this would be much larger but there are OOM issues.
-        "batch_size": 16,
+        "batch_size": 14,
     },
     "validation_iterator": {
         "type": "basic",

--- a/contrastive.jsonnet
+++ b/contrastive.jsonnet
@@ -60,7 +60,7 @@ local token_embedding_size = 768;
     "iterator": {
         "type": "basic",
         // TODO (John): Ideally this would be much larger but there are OOM issues.
-        "batch_size": 14,
+        "batch_size": 16,
     },
     "validation_iterator": {
         "type": "basic",

--- a/scripts/run_senteval_benchmark.py
+++ b/scripts/run_senteval_benchmark.py
@@ -1,79 +1,121 @@
-# Copyright (c) 2017-present, Facebook, Inc.
-# All rights reserved.
-#
-# This source code is licensed under the license found in the
-# LICENSE file in the root directory of this source tree.
-#
-
 from __future__ import absolute_import, division, unicode_literals
 
-import io
+import json
 import logging
+import os
 import sys
 from pathlib import Path
+from typing import List
 
 import numpy as np
+import typer
+
 from allennlp.common import Params
+from allennlp.common import util as common_util
 from allennlp.data import DatasetReader
 from allennlp.models.model import Model
-from allennlp.predictors import Predictor
 
-# Set PATHs
-PATH_TO_SENTEVAL = 'SentEval'
-PATH_TO_DATA = 'SentEval/data'
-PATH_TO_ALLENLP_ARCHIVE = ''
-CUDA_DEVICE = 0
+# Set up logger
+logging.basicConfig(format='%(asctime)s : %(message)s', level=logging.DEBUG)
 
-# import SentEval
-sys.path.insert(0, PATH_TO_SENTEVAL)
-sys.path.insert(1, '../t2t')
-import senteval
-from t2t.models import ContrastiveTextEncoder
-from t2t.data.dataset_readers import ContrastiveDatasetReader
+
+def main(
+    path_to_senteval: str,
+    path_to_allennlp_archive: str,
+    prototyping_config: bool = False,
+    cuda_device: int = -1,
+    overrides: str = "",
+    include_package: List[str] = None,
+) -> None:
+    """Evaluates a trained AllenNLP model against the SentEval benchmark.
+    """
+    # Set params for SentEval
+    # See: https://github.com/facebookresearch/SentEval#senteval-parameters for explanation of the protoype config
+    path_to_data = os.path.join(path_to_senteval, 'data')
+    if prototyping_config:
+        typer.secho(
+            f"\U000026A0 Using prototyping config. Pass --no-prototyping-config to get results comparable to the literature.",
+            fg=typer.colors.YELLOW,
+            bold=True
+        )
+        params_senteval = {'task_path': path_to_data, 'usepytorch': True, 'kfold': 5}
+        params_senteval['classifier'] = {'nhid': 0, 'optim': 'rmsprop', 'batch_size': 128,
+                                         'tenacity': 3, 'epoch_size': 2}
+    else:
+        params_senteval = {'task_path': path_to_data, 'usepytorch': True, 'kfold': 10}
+        params_senteval['classifier'] = {'nhid': 0, 'optim': 'adam', 'batch_size': 64,
+                                         'tenacity': 5, 'epoch_size': 4}
+
+    # Load an AllenNLP Model
+    load_model(params_senteval, path_to_allennlp_archive, cuda_device, overrides, include_package)
+
+    # Run SentEval
+    run_senteval(params_senteval, path_to_senteval)
+
 
 # SentEval prepare and batcher
 def prepare(params, samples):
     return
 
-def batcher(params, batch):s
+
+def batcher(params, batch):
     instances = [params.reader.text_to_instance(" ".join(tokenized_text)) for tokenized_text in batch]
     outputs = params.model.forward_on_instances(instances)
     embeddings = np.vstack([output['embeddings'] for output in outputs])
 
     return embeddings
 
-# Set params for SentEval
-params_senteval = {'task_path': PATH_TO_DATA, 'usepytorch': True, 'kfold': 5}
-params_senteval['classifier'] = {'nhid': 0, 'optim': 'rmsprop', 'batch_size': 128,
-                                 'tenacity': 3, 'epoch_size': 2}
 
-# Set up logger
-logging.basicConfig(format='%(asctime)s : %(message)s', level=logging.DEBUG)
+def load_model(
+    params,
+    path_to_allennlp_archive: str,
+    cuda_device: int = -1,
+    overrides: str = "",
+    include_package: List[str] = None,
+) -> None:
+    # This allows us to import custom dataset readers and models that may exist in the AllenNLP archive.
+    # See: https://github.com/allenai/allennlp/blob/e19605aae05eff60b0f41dc521b9787867fa58dd/allennlp/commands/train.py#L404
+    include_package = include_package or []
+    for package_name in include_package:
+        common_util.import_module_and_submodules(package_name)
 
-if __name__ == "__main__":
-    # Load an AllenNLP Model ######################################################################################
-    serialization_dir = Path(PATH_TO_ALLENLP_ARCHIVE)
+    serialization_dir = Path(path_to_allennlp_archive)
     config_filepath = serialization_dir / 'config.json'
-    allennlp_params = Params.from_file(config_filepath)
+    allennlp_params = Params.from_file(config_filepath, overrides)
     dataset_reader_params = allennlp_params["dataset_reader"]
 
-    # TODO (John): Is there a way to use --include-package so that these do not need to be
-    # fully specified paths
-    allennlp_params['model']['type'] = 't2t.models.contrastive_text_encoder.ContrastiveTextEncoder'
-    dataset_reader_params['type'] = 't2t.data.dataset_readers.contrastive.ContrastiveDatasetReader'
-
-    dataset_reader_params['sample_spans'] = False
-
+    # Load the archived DatasetReader
     reader = DatasetReader.from_params(dataset_reader_params)
+    typer.secho(
+        f"\U00002705 DatasetReader from AllenNLP archive loaded successfully.",
+        fg=typer.colors.GREEN,
+        bold=True
+    )
+
+    # Load the archived AllenNLP model
     model = Model.load(
-        allennlp_params, serialization_dir=serialization_dir, cuda_device=CUDA_DEVICE
+        allennlp_params, serialization_dir=serialization_dir, cuda_device=cuda_device
     ).eval()
+    typer.secho(f"\U00002705 Model from AllenNLP archive loaded successfully", fg=typer.colors.GREEN, bold=True)
 
-    params_senteval['reader'] = reader
-    params_senteval['model'] = model
-    ###############################################################################################################
+    params['reader'] = reader
+    params['model'] = model
 
-    se = senteval.engine.SE(params_senteval, batcher, prepare)
+    return
+
+
+def run_senteval(params, path_to_senteval: str):
+    # Import SentEval
+    sys.path.insert(0, path_to_senteval)
+    import senteval
+
+    typer.secho(
+        f"\U00002705 SentEval repository and transfer task data loaded successfully.",
+        fg=typer.colors.GREEN,
+        bold=True
+    )
+
+    se = senteval.engine.SE(params, batcher, prepare)
     transfer_tasks = ['STS12', 'STS13', 'STS14', 'STS15', 'STS16',
                       'MR', 'CR', 'MPQA', 'SUBJ', 'SST2', 'SST5', 'TREC', 'MRPC',
                       'SICKEntailment', 'SICKRelatedness', 'STSBenchmark',
@@ -81,4 +123,11 @@ if __name__ == "__main__":
                       'BigramShift', 'Tense', 'SubjNumber', 'ObjNumber',
                       'OddManOut', 'CoordinationInversion']
     results = se.eval(transfer_tasks)
-    print(results)
+    # TODO (John): It would be great if we could:
+    #   1. Format this nicely as a table.
+    #   2. Save it to disk as a CSV or something comparable.
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/scripts/run_senteval_benchmark.py
+++ b/scripts/run_senteval_benchmark.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+from __future__ import absolute_import, division, unicode_literals
+
+import io
+import logging
+import sys
+from pathlib import Path
+
+import numpy as np
+from allennlp.common import Params
+from allennlp.data import DatasetReader
+from allennlp.models.model import Model
+from allennlp.predictors import Predictor
+
+# Set PATHs
+PATH_TO_SENTEVAL = 'SentEval'
+PATH_TO_DATA = 'SentEval/data'
+PATH_TO_ALLENLP_ARCHIVE = ''
+CUDA_DEVICE = 0
+
+# import SentEval
+sys.path.insert(0, PATH_TO_SENTEVAL)
+sys.path.insert(1, '../t2t')
+import senteval
+from t2t.models import ContrastiveTextEncoder
+from t2t.data.dataset_readers import ContrastiveDatasetReader
+
+# SentEval prepare and batcher
+def prepare(params, samples):
+    return
+
+def batcher(params, batch):s
+    instances = [params.reader.text_to_instance(" ".join(tokenized_text)) for tokenized_text in batch]
+    outputs = params.model.forward_on_instances(instances)
+    embeddings = np.vstack([output['embeddings'] for output in outputs])
+
+    return embeddings
+
+# Set params for SentEval
+params_senteval = {'task_path': PATH_TO_DATA, 'usepytorch': True, 'kfold': 5}
+params_senteval['classifier'] = {'nhid': 0, 'optim': 'rmsprop', 'batch_size': 128,
+                                 'tenacity': 3, 'epoch_size': 2}
+
+# Set up logger
+logging.basicConfig(format='%(asctime)s : %(message)s', level=logging.DEBUG)
+
+if __name__ == "__main__":
+    # Load an AllenNLP Model ######################################################################################
+    serialization_dir = Path(PATH_TO_ALLENLP_ARCHIVE)
+    config_filepath = serialization_dir / 'config.json'
+    allennlp_params = Params.from_file(config_filepath)
+    dataset_reader_params = allennlp_params["dataset_reader"]
+
+    # TODO (John): Is there a way to use --include-package so that these do not need to be
+    # fully specified paths
+    allennlp_params['model']['type'] = 't2t.models.contrastive_text_encoder.ContrastiveTextEncoder'
+    dataset_reader_params['type'] = 't2t.data.dataset_readers.contrastive.ContrastiveDatasetReader'
+
+    dataset_reader_params['sample_spans'] = False
+
+    reader = DatasetReader.from_params(dataset_reader_params)
+    model = Model.load(
+        allennlp_params, serialization_dir=serialization_dir, cuda_device=CUDA_DEVICE
+    ).eval()
+
+    params_senteval['reader'] = reader
+    params_senteval['model'] = model
+    ###############################################################################################################
+
+    se = senteval.engine.SE(params_senteval, batcher, prepare)
+    transfer_tasks = ['STS12', 'STS13', 'STS14', 'STS15', 'STS16',
+                      'MR', 'CR', 'MPQA', 'SUBJ', 'SST2', 'SST5', 'TREC', 'MRPC',
+                      'SICKEntailment', 'SICKRelatedness', 'STSBenchmark',
+                      'Length', 'WordContent', 'Depth', 'TopConstituents',
+                      'BigramShift', 'Tense', 'SubjNumber', 'ObjNumber',
+                      'OddManOut', 'CoordinationInversion']
+    results = se.eval(transfer_tasks)
+    print(results)

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,6 @@ setuptools.setup(
         "allennlp>=0.9.0",
         "torch>=1.2.0",
         "pytorch-metric-learning>=0.9.73",
+        "typer>=0.0.8"
     ],
 )


### PR DESCRIPTION
# Overview

This PR adds support for easily evaluating a trained model against the SentEval benchmark.

## Other Changes

- Fixed some :bug:'s introduced in last PR. This is why I need to write tests!

## TODO

- [x] General cleanup of SentEval script. Make it possible to specify args via the command line, don't require a user to modify the script directly.
- [x] Link mention of the script in README to GitHub file tree.
