### PR TITLE
Register loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ python scripts/run_senteval.py allennlp SentEval tmp \
  --cuda-device 0  \
  --overrides '{"dataset_reader.sample_spans": false}' \
  --include-package t2t
- --output_filepath
 ```
 
 The results will be saved to `tmp/senteval_results.json`. This can be changed to any path you like.

--- a/contrastive.jsonnet
+++ b/contrastive.jsonnet
@@ -36,7 +36,6 @@ local token_embedding_size = 768;
     "validation_data_path": "",
     "model": {
         "type": "constrastive",
-        "temperature": 0.1,
         "text_field_embedder": {
             "token_embedders": {
                 "tokens": {
@@ -56,11 +55,16 @@ local token_embedding_size = 768;
             "hidden_dims": [128, 128],
             "activations": ["relu", "linear"],
         },
+        "loss": {
+            "type": "nt-xent",
+            "temperature": 0.1,
+            "normalize_embeddings": true
+        },
     },
     "iterator": {
         "type": "basic",
         // TODO (John): Ideally this would be much larger but there are OOM issues.
-        "batch_size": 14,
+        "batch_size": 12,
     },
     "validation_iterator": {
         "type": "basic",
@@ -76,7 +80,6 @@ local token_embedding_size = 768;
                 # See: https://github.com/huggingface/transformers/blob/2184f87003c18ad8a172ecab9a821626522cf8e7/examples/run_ner.py#L105
                 # Regex: https://regex101.com/r/ZUyDgR/3/tests
                 [["(?=.*transformer_model)(?=.*\\.+)(?!.*(LayerNorm|bias)).*$"], {"weight_decay": 0.01}],
-                # TODO (John): Apply a different (smaller) learning rate to the seq2seq encoder as it is pre-trained
             ],
         },
         "patience": 5,

--- a/scripts/run_senteval.py
+++ b/scripts/run_senteval.py
@@ -46,7 +46,7 @@ def _setup_senteval(path_to_senteval: str, prototyping_config: bool = False, ver
     if prototyping_config:
         typer.secho(
             (f"{WARNING} Using prototyping config. Pass --no-prototyping-config to get results comparable to the"
-             "literature."),
+             " literature."),
             fg=typer.colors.YELLOW,
             bold=True
         )

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
     install_requires=[
         "allennlp>=0.9.0",
         "torch>=1.2.0",
-        "pytorch-metric-learning>=0.9.73",
+        "pytorch-metric-learning>=0.9.75",
         "typer>=0.0.8"
     ],
 )

--- a/t2t/losses/__init__.py
+++ b/t2t/losses/__init__.py
@@ -1,0 +1,2 @@
+from t2t.losses.pytorch_metric_learning_loss import (NTXentLoss,
+                                                     PyTorchMetricLearningLoss)

--- a/t2t/losses/pytorch_metric_learning_loss.py
+++ b/t2t/losses/pytorch_metric_learning_loss.py
@@ -7,6 +7,13 @@ from allennlp.common import Registrable
 
 
 class PyTorchMetricLearningLoss(Registrable):
+    """This class just allows us to implement `Registrable` for PyTorch Metric Learning loss functions.
+    Subclasses of this class should also subclass a loss function from PyTorch Metric Learning
+    (see: https://github.com/KevinMusgrave/pytorch-metric-learning), and accept as arguments
+    to the constructor the same arguments that the loss function does, as well as the `BaseMetricLossFunction`
+    (see: https://kevinmusgrave.github.io/pytorch-metric-learning/losses/#basemetriclossfunction).
+    See `NTXentLoss` below as an example.
+    """
 
     @classmethod
     def get_embeddings_and_labels(

--- a/t2t/losses/pytorch_metric_learning_loss.py
+++ b/t2t/losses/pytorch_metric_learning_loss.py
@@ -1,0 +1,58 @@
+from typing import List, Tuple
+
+import torch
+from pytorch_metric_learning.losses import NTXentLoss as NTXent
+
+from allennlp.common import Registrable
+
+
+class PyTorchMetricLearningLoss(Registrable):
+
+    @classmethod
+    def get_embeddings_and_labels(
+        self,
+        anchors: torch.Tensor,
+        positives: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Formats a pair of anchor, positive embeddings for use with a PyTorch Metric Learning loss function
+        (https://github.com/KevinMusgrave/pytorch-metric-learning). These loss functions expect a single embedding
+        tensor, and a corresponding set of labels. Given two tensors: `anchor_embeddings` and `positive_embeddings`
+        each of shape `(batch_size, embedding_dim)`, concatenate them along the first dimension to produce a single
+        tensor, `embeddings`, of shape `(batch_size * 2, embedding_dim)`. Then, generate the corresponding `labels`
+        tensor of shape `(batch_size * 2)` by assigning a matching integer index to each pair of anchor, positive
+        embeddings in `embeddings`.
+
+        # Parameters
+
+        anchor_embeddings : `torch.Tensor`
+            Encoded representations of the anchors.
+        positive_embeddings : `torch.Tensor`
+            Encoded representations of the positives.
+
+        # Returns
+
+        A tuple of embeddings and labels that can be fed directly to any PyTorch-Metric-Learning loss function.
+        """
+        embeddings = torch.cat((anchors, positives))
+        indices = torch.arange(0, anchors.size(0), device=anchors.device)
+        labels = torch.cat((indices, indices))
+
+        return embeddings, labels
+
+
+@PyTorchMetricLearningLoss.register('nt-xent')
+class NTXentLoss(PyTorchMetricLearningLoss, NTXent):
+    def __init__(
+        self,
+        temperature: float,
+        normalize_embeddings: bool = True,
+        num_class_per_param: int = None,
+        learnable_param_names: List[str] = None
+    ) -> None:
+
+        super().__init__(
+            temperature=temperature,
+            normalize_embeddings=normalize_embeddings,
+            num_class_per_param=num_class_per_param,
+            learnable_param_names=learnable_param_names
+        )

--- a/t2t/models/contrastive_text_encoder.py
+++ b/t2t/models/contrastive_text_encoder.py
@@ -47,7 +47,7 @@ class ContrastiveTextEncoder(Model):
         feedforward: Optional[FeedForward] = None,
         loss: PyTorchMetricLearningLoss = None,
         initializer: InitializerApplicator = InitializerApplicator(),
-        **kwargs,
+        **kwargs
     ) -> None:
 
         super().__init__(vocab, **kwargs)
@@ -138,3 +138,21 @@ class ContrastiveTextEncoder(Model):
                 output_dict["projections"] = embedded_text.clone().detach()
 
         return embedded_text
+
+
+
+def my_func(line):
+    # 1
+    first_city, split = line.split(':')
+
+    # 2
+    second_city = ''
+    distance = ''
+
+    for ch in split:
+        if ch.isdigit():
+            distance += ch
+        else:
+            second_city += ch
+
+    return first_city, second_city.strip(), int(distance)

--- a/t2t/models/util.py
+++ b/t2t/models/util.py
@@ -6,36 +6,6 @@ import torch
 from allennlp.data import TextFieldTensors
 
 
-def format_embed_pt_metric_loss(
-    anchor_embeddings: torch.Tensor,
-    positive_embeddings: torch.Tensor
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """A helper function which formats a pair of anchor, positive embeddings for use with a
-    PyTorch Metric Learning loss function (https://github.com/KevinMusgrave/pytorch-metric-learning).
-    These loss functions expect a single embedding tensor, and a corresponding set of labels. Given two tensors:
-    `anchor_embeddings` and `positive_embeddings` each of shape `(batch_size, embedding_dim)`, concatenate them
-    along the first dimension to produce a single tensor, `embeddings`, of shape `(batch_size * 2, embedding_dim)`.
-    Then, generate the corresponding `labels` tensor of shape `(batch_size * 2)` by assigning a matching integer
-    index to each pair of anchor, positive embeddings in `embeddings`.
-
-    # Parameters
-
-    anchor_embeddings : `torch.Tensor`
-        Encoded representations of the anchors.
-    positive_embeddings : `torch.Tensor`
-        Encoded representations of the positives.
-
-    # Returns
-
-    A tuple of embeddings and labels that can be fed directly to any PyTorch-Metric-Learning loss function.
-    """
-    embeddings = torch.cat((anchor_embeddings, positive_embeddings))
-    indices = torch.arange(0, anchor_embeddings.size(0), device=anchor_embeddings.device)
-    labels = torch.cat((indices, indices))
-
-    return embeddings, labels
-
-
 def sample_anchor_positive_pairs(tokens) -> Tuple[TextFieldTensors, TextFieldTensors]:
     """Returns a tuple of `TextFieldTensors` containing random batches of anchors and positives from tokens.
 


### PR DESCRIPTION
# Overview

This PR makes any loss function in the [PyTorch Metric Learning library](https://github.com/KevinMusgrave/pytorch-metric-learning) "registerable".  Getting this to work was actually a little tricky. But in the future, you only need to:

1. Create a class which subclasses our `PyTorchMetricLearningLoss` and the loss function from [PyTorch Metric Learning loss](https://kevinmusgrave.github.io/pytorch-metric-learning/losses/) that you want to use.
2. Call the super constructor with all arguments to that loss function, as well as the [`BaseMetricLossFunction`](https://kevinmusgrave.github.io/pytorch-metric-learning/losses/#basemetriclossfunction) class.

Here is how it looks for  [NTXentLoss](https://kevinmusgrave.github.io/pytorch-metric-learning/losses/#ntxentloss):

```python
@PyTorchMetricLearningLoss.register('nt-xent')
class NTXentLoss(PyTorchMetricLearningLoss, NTXent):
    def __init__(
        self,
        temperature: float,
        normalize_embeddings: bool = True,
        num_class_per_param: int = None,
        learnable_param_names: List[str] = None
    ) -> None:

        super().__init__(
            temperature=temperature,
            normalize_embeddings=normalize_embeddings,
            num_class_per_param=num_class_per_param,
            learnable_param_names=learnable_param_names
        )
```

You can now use the loss in your jsonnet config, e.g.,

```json
...
        "loss": {
            "type": "nt-xent",
            "temperature": 0.1,
            "normalize_embeddings": true
        },
...
```

This was important for two reasons:

1. It keeps the loss function modular. The heart of this project is developing a skeleton for contrastive learning of textual representations and we don't want to be wedded to any particular encoder/projection head/loss function etc.
2. The parameters of the loss function are now serialized in the config, making every experiment reproducible.

## TODO

- [ ] I don't like that we have to call `get_embeddings_and_labels` in the model. Find a way to call this in the loss function instead? (#40)

## Closes

Closes #34.