### PR TITLE
Add predictor

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ allennlp predict tmp path/to/input.txt \
  --batch-size 32 \
  --cuda-device 0 \
  --use-dataset-reader \
- --overrides '{"dataset_reader.sample_spans": false}' \
+ --predictor "contrastive" \
  --include-package t2t
 ```
 
@@ -90,10 +90,9 @@ cd SentEval/data/downstream/
 Then you can run our [script](scripts/run_senteval.py) to evaluate a trained model against SentEval
 
 ```bash
-python scripts/run_senteval.py allennlp SentEval tmp \
+python scripts/run_senteval.py allennlp SentEval tmp "contrastive" \
  --output-filepath tmp/senteval_results.json \
  --cuda-device 0  \
- --overrides '{"dataset_reader.sample_spans": false}' \
  --include-package t2t
 ```
 

--- a/configs/contrastive.jsonnet
+++ b/configs/contrastive.jsonnet
@@ -9,6 +9,8 @@ local max_length = 512;
 // TODO (John): Can we set this programatically?
 // This corresponds to the config.hidden_size of pretrained_transformer_model_name
 local token_embedding_size = 768;
+// The size of the embeddings produced by the projection head
+local projection_size = 128;
 
 {
     "dataset_reader": {
@@ -51,7 +53,7 @@ local token_embedding_size = 768;
         "feedforward": {
             "input_dim": token_embedding_size,
             "num_layers": 2,
-            "hidden_dims": [128, 128],
+            "hidden_dims": [projection_size, projection_size],
             "activations": ["relu", "linear"],
         },
         "loss": {

--- a/configs/contrastive_distributed.jsonnet
+++ b/configs/contrastive_distributed.jsonnet
@@ -9,6 +9,8 @@ local max_length = 512;
 // TODO (John): Can we set this programatically?
 // This corresponds to the config.hidden_size of pretrained_transformer_model_name
 local token_embedding_size = 768;
+// The size of the embeddings produced by the projection head
+local projection_size = 128;
 
 {
     "dataset_reader": {
@@ -50,7 +52,7 @@ local token_embedding_size = 768;
         "feedforward": {
             "input_dim": token_embedding_size,
             "num_layers": 2,
-            "hidden_dims": [128, 128],
+            "hidden_dims": [projection_size, projection_size],
             "activations": ["relu", "linear"],
         },
         "loss": {

--- a/scripts/create_contrastive_training_data.py
+++ b/scripts/create_contrastive_training_data.py
@@ -28,17 +28,17 @@ def main(input_file: str, output_file: str, spacy_model: str = "en_core_web_sm")
             python -m spacy download <spacy_model>`. Defaults to `"en_core_web_sm"`.
     """
 
-    print('Loading tokenizer...', end=' ', flush=True)
-    nlp = spacy.load(spacy_model, disable=['ner'])
-    print('Done.')
+    print("Loading tokenizer...", end=" ", flush=True)
+    nlp = spacy.load(spacy_model, disable=["ner"])
+    print("Done.")
 
-    anchors = Path(input_file).read_text().split('\n')
+    anchors = Path(input_file).read_text().split("\n")
     positives = _generate_positives(anchors, nlp)
 
-    print(f'Saving generated training data to {output_file}...', end=' ', flush=True)
+    print(f"Saving generated training data to {output_file}...", end=" ", flush=True)
     train_data = zip(anchors, positives)
     _save_train_data_to_disk(output_file, train_data)
-    print('Done.')
+    print("Done.")
 
 
 def _generate_positives(anchors: List[str], nlp: spacy.lang):
@@ -55,7 +55,7 @@ def _generate_positives(anchors: List[str], nlp: spacy.lang):
     positives = []
 
     docs = nlp.pipe(anchors, n_process=-1)
-    for doc in tqdm(docs, total=len(anchors), desc='Generating positive examples', dynamic_ncols=True):
+    for doc in tqdm(docs, total=len(anchors), desc="Generating positive examples", dynamic_ncols=True):
         # TODO (John): We don't want especially short sentences as they contain little information. As a temporary
         # hack, take the longest sentence from each anchor.
         sents = list(doc.sents)
@@ -64,9 +64,7 @@ def _generate_positives(anchors: List[str], nlp: spacy.lang):
             dropped += 1
             continue
 
-        positives.append(
-            sorted(sents, key=len)[-1].text
-        )
+        positives.append(sorted(sents, key=len)[-1].text)
 
     if dropped:
         print(f"Dropped {dropped}/{len(anchors)} ({dropped/len(anchors):.2%}) anchors with no sentences.")

--- a/scripts/create_pubmed_citation_triplet_standard.py
+++ b/scripts/create_pubmed_citation_triplet_standard.py
@@ -3,9 +3,7 @@ import json
 import pickle
 import random
 from pathlib import Path
-from typing import Dict
-from typing import List
-from typing import Tuple
+from typing import Dict, List, Tuple
 
 import fire
 from tqdm import tqdm
@@ -23,7 +21,7 @@ def main(
     pos_threshold: float = 0.2,
     neg_threshold: float = 0.001,
     neg_margin: float = 0.015,
-    cache: bool = False
+    cache: bool = False,
 ) -> None:
     """Generates a set of triplets of PMIDs which, among other things, can be used to evaluate document embeddings.
 
@@ -120,9 +118,7 @@ def _load_and_cache_icite_metadata(input_dir: Path, output_dir: Path, cache: boo
 
 
 def _parse_icite_metadata(
-    input_dir: Path,
-    research_only: bool = True,
-    citation_count_threshold: int = 10
+    input_dir: Path, research_only: bool = True, citation_count_threshold: int = 10
 ) -> Dict[str, set]:
 
     citations = {}
@@ -134,8 +130,9 @@ def _parse_icite_metadata(
                 contents = json.loads(line)
 
                 # Filter anything that isn't a reasearch article or has less than citation_count_threshold citations
-                if ((not contents["is_research_article"] and research_only) or
-                   contents["citation_count"] < citation_count_threshold):
+                if (not contents["is_research_article"] and research_only) or contents[
+                    "citation_count"
+                ] < citation_count_threshold:
                     continue
 
                 pmid = str(contents["pmid"])
@@ -155,7 +152,7 @@ def _compute_similarity(
     citations: Dict[str, Dict[str, List]],
     pos_threshold: float,
     neg_threshold: float,
-    neg_margin: float
+    neg_margin: float,
 ) -> List[Tuple[str, str, str]]:
     """Returns triplets of PMIDs from `pmid_pairs` where the first two PMIDs are most closely related. Only PMIDs
     with similarity scores greatert than or equal to `pos_threshold` are retained. The similarity score is computed
@@ -217,7 +214,7 @@ def _generate_triplets(
     max_triplets: int,
     pos_threshold: float,
     neg_threshold: float,
-    neg_margin: float
+    neg_margin: float,
 ) -> List[Tuple[str, str, str]]:
 
     pmids = set(citations.keys())
@@ -256,8 +253,12 @@ def _generate_triplets(
             triplets = triplets[:max_triplets]  # drop triplets over the max number requested
             break
 
-    print((f"Generated {len(triplets)} triplets of PMIDs with a positive threshold of {pos_threshold}, a"
-           f" negative threshold of {neg_threshold} and a negative margin of {neg_margin}"))
+    print(
+        (
+            f"Generated {len(triplets)} triplets of PMIDs with a positive threshold of {pos_threshold}, a"
+            f" negative threshold of {neg_threshold} and a negative margin of {neg_margin}"
+        )
+    )
 
     return triplets
 

--- a/scripts/embed_with_transformer.py
+++ b/scripts/embed_with_transformer.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """A simple script which uses a pre-trained transformer to encode some documents, saving the
 resulting emebddings to disk. We wrap the Transformers library
 (https://github.com/huggingface/transformers), so you can use any of the pre-trained models listed
@@ -7,52 +8,84 @@ Call `python embed_with_transformer.py --help` for usage instructions.
 """
 
 import json
+from enum import Enum
 from pathlib import Path
-from typing import List
-from typing import Tuple
+from typing import List, Tuple
 
-import fire
 import torch
-from tqdm import trange
-from transformers import AutoModel
-from transformers import AutoTokenizer
+import transformers
+import typer
+from transformers import AutoModel, AutoTokenizer
+
+# Emoji's used in typer.secho calls
+# See: https://github.com/carpedm20/emoji/blob/master/emoji/unicode_codes.py
+WARNING = "\U000026A0"
+SUCCESS = "\U00002705"
+RUNNING = "\U000023F3"
+SAVING = "\U0001F4BE"
+FAST = "\U0001F3C3"
+SCORE = "\U0001F4CB"
+
+
+class Pooler(str, Enum):
+    mean = "mean"
+    cls = "cls"
 
 
 def main(
     pretrained_model_name_or_path: str,
-    input_file: str,
-    output_file: str,
+    input_filepath: str,
+    output_filepath: str,
     batch_size: int = 16,
+    pooler: Pooler = Pooler.mean,
     disable_cuda: bool = False,
     opt_level: str = None,
 ) -> None:
+    """Uses a pre-trained transformer to encode some documents, saving the resulting emebddings to disk. We wrap
+    the Transformers library (https://github.com/huggingface/transformers), so you can use any of the pre-trained
+    models listed here: https://huggingface.co/transformers/pretrained_models.html.
+    """
 
     device = _get_device(disable_cuda)
 
-    print('Loading model and tokenizer...', end=' ', flush=True)
     tokenizer, model = _init_model_and_tokenizer(pretrained_model_name_or_path, device, opt_level)
-    print('Done.')
 
-    text = Path(input_file).read_text().split('\n')
-    embeddings = _embed(text, tokenizer, model, batch_size, device)
+    text = Path(input_filepath).read_text().split("\n")
+    embeddings = _embed(text, tokenizer, model, pooler, batch_size, device)
 
-    print(f'Saving document embeddings to {output_file}...', end=' ', flush=True)
-    _save_embeddings_to_disk(output_file, embeddings)
-    print('Done.')
+    _save_embeddings_to_disk(output_filepath, embeddings)
 
 
 def _get_device(disable_cuda):
     if not disable_cuda and torch.cuda.is_available():
-        device = torch.device('cuda')
+        device = torch.device("cuda")
+        typer.secho(
+            f"{FAST} Using GPU device: {torch.cuda.current_device()}", fg=typer.colors.WHITE, bold=True,
+        )
     else:
-        device = torch.device('cpu')
+        device = torch.device("cpu")
 
     return device
 
 
-def _init_model_and_tokenizer(pretrained_model_name_or_path: str, device: torch.device, opt_level: str) -> Tuple:
+def _init_model_and_tokenizer(
+    pretrained_model_name_or_path: str, device: torch.device, opt_level: str
+) -> Tuple[transformers.PreTrainedTokenizer, transformers.PreTrainedModel]:
+    # Load the Transformers tokenizer
     tokenizer = AutoTokenizer.from_pretrained(pretrained_model_name_or_path)
+    typer.secho(
+        f'{SUCCESS} Tokenizer "{pretrained_model_name_or_path}" from Transformers loaded successfully.',
+        fg=typer.colors.GREEN,
+        bold=True,
+    )
+    # Load the Transformers model
     model = AutoModel.from_pretrained(pretrained_model_name_or_path).to(device)
+    model.eval()
+    typer.secho(
+        f'{SUCCESS} Model "{pretrained_model_name_or_path}" from Transformers loaded successfully.',
+        fg=typer.colors.GREEN,
+        bold=True,
+    )
 
     if opt_level is not None:
         try:
@@ -65,63 +98,82 @@ def _init_model_and_tokenizer(pretrained_model_name_or_path: str, device: torch.
     return tokenizer, model
 
 
-def _embed(texts: List[str], tokenizer, model, batch_size: int, device: torch.device) -> List[float]:
+def _embed(
+    texts: List[str],
+    tokenizer: transformers.PreTrainedTokenizer,
+    model: transformers.PreTrainedModel,
+    pooler: Pooler,
+    batch_size: int,
+    device: torch.device,
+) -> List[float]:
     """Using `model` and its corresponding `tokenizer`, encodes each instance in `text` and returns
     the resulting list of embeddings.
 
     Args:
         text (List[str]): A list containing the text instances to embed.
-        tokenizer ([type]): An initialized tokenizer from the Transformers library.
-        model ([type]): An initialized model from the Transformers library.
+        tokenizer (PreTrainedTokenizer): An initialized tokenizer from the Transformers library.
+        model (PreTrainedModel): An initialized model from the Transformers library.
         batch_size (int): Batch size to use when embedding instances in `text`.
         device (torch.device): A torch.device object specifying which device (cpu or gpu) to use.
+        pooler (str): Controls the pooling strategy. A choice of (mean, cls).
 
     Returns:
-        List[float]: A list containing the embeddings for each instance in `text`.
+        List[float]: A list containing the embeddings for each instance in `texts`.
     """
-    input_ids = torch.tensor([tokenizer.encode(text, max_length=512, pad_to_max_length=True) for text in texts])
-    attention_masks = torch.where(
-        input_ids == tokenizer.pad_token_id,
-        torch.zeros_like(input_ids),
-        torch.ones_like(input_ids)
+    # To embed with transformers, we (minimally) need the input ids and the attention masks.
+    input_ids = torch.as_tensor(
+        # TODO (John): Hardcoded this for now because of error with BioBERT
+        [tokenizer.encode(text, max_length=512, pad_to_max_length=True) for text in texts],
+    )
+    attention_mask = torch.where(
+        input_ids == tokenizer.pad_token_id, torch.zeros_like(input_ids), torch.ones_like(input_ids)
     )
 
-    doc_embeddings = []
-    for i in trange(0, input_ids.size(0), batch_size, desc='Embedding documents', dynamic_ncols=True):
-        batch = {
-            "input_ids": input_ids[i:i+batch_size].to(device),
-            "attention_mask": attention_masks[i:i+batch_size].to(device)
-        }
+    embeddings = []
+    with typer.progressbar(range(0, input_ids.size(0), batch_size), label="Embedding") as progress:
+        for batch_idx in progress:
+            batch = {
+                "input_ids": input_ids[batch_idx : batch_idx + batch_size].to(device),
+                "attention_mask": attention_mask[batch_idx : batch_idx + batch_size, :].to(device),
+            }
+            with torch.no_grad():
+                sequence_output, pooled_output = model(**batch)
 
-        word_embeddings, _ = model(**batch)
-        doc_embeddings.extend(
-            (torch.sum(word_embeddings * batch['attention_mask'].unsqueeze(-1), dim=1) /
-             torch.clamp(torch.sum(batch['attention_mask'], dim=1, keepdims=True), min=1e-9)).tolist()
-        )
+            # When mean pooling, we take the average of the token-level embeddings, accounting for pads.
+            # Otherwise, we take the pooled output for this specific model, which is typically the linear
+            # projection of a special tokens embedding, like [CLS] or <s>, which is prepended to the input during
+            # tokenization.
+            if pooler.value == "mean":
+                pooled_output = torch.sum(
+                    sequence_output * batch["attention_mask"].unsqueeze(-1), dim=1
+                ) / torch.clamp(torch.sum(batch["attention_mask"], dim=1, keepdims=True), min=1e-9)
 
-        del batch
+            pooled_output = pooled_output.tolist()
+            embeddings.extend(pooled_output)
 
-    return doc_embeddings
+    return embeddings
 
 
-def _save_embeddings_to_disk(output_file: str, embeddings: List[float]) -> None:
-    """Saves `embeddings` to a JSON lines formatted file `output_file`. Each line looks like:
+def _save_embeddings_to_disk(output_filepath: str, embeddings: List[float]) -> None:
+    """Saves `embeddings` to a JSON lines formatted file `output_filepath`. Each line looks like:
 
-        {"doc_embeddings": [-0.4989708960056305, ..., 0.19127938151359558]}
+        {"embeddings": [-0.4989708960056305, ..., 0.19127938151359558]}
 
     Args:
-        output_file (str): Path to save the embeddings.
+        output_filepath (str): Path to save the embeddings.
         embeddings (List[float]): A list of lists, containing one embedding per document.
     """
-    output_file = Path(output_file)
-    output_file.parents[0].mkdir(parents=True, exist_ok=True)
+    output_filepath = Path(output_filepath)
+    output_filepath.parents[0].mkdir(parents=True, exist_ok=True)
 
-    with open(output_file, 'w') as f:
+    with open(output_filepath, "w") as f:
         # Format the embeddings in JSON lines format
         for embedding in embeddings:
-            json.dump({'doc_embeddings': embedding}, f)
-            f.write('\n')
+            json.dump({"embeddings": embedding}, f)
+            f.write("\n")
+
+    typer.secho(f"{SAVING} Results saved to: {output_filepath}", fg=typer.colors.WHITE, bold=True)
 
 
-if __name__ == '__main__':
-    fire.Fire(main)
+if __name__ == "__main__":
+    typer.run(main)

--- a/scripts/embed_with_word2vec.py
+++ b/scripts/embed_with_word2vec.py
@@ -22,21 +22,21 @@ SPACY_MODEL = "en_core_web_sm"
 
 def main(input_file: str, output_file: str, word_vectors: str, binary: bool = False) -> None:
 
-    print('Loading model and tokenizer...', end=' ', flush=True)
+    print("Loading model and tokenizer...", end=" ", flush=True)
     nlp, model = _init_model_and_tokenizer(word_vectors, binary)
-    print('Done.')
+    print("Done.")
 
-    texts = Path(input_file).read_text().split('\n')
+    texts = Path(input_file).read_text().split("\n")
     embeddings = _embed(texts, nlp, model)
 
-    print(f'Saving document embeddings to {output_file}...', end=' ', flush=True)
+    print(f"Saving document embeddings to {output_file}...", end=" ", flush=True)
     _save_embeddings_to_disk(output_file, embeddings)
-    print('Done.')
+    print("Done.")
 
 
 def _init_model_and_tokenizer(word_vectors: str, binary: bool) -> Tuple:
 
-    nlp = spacy.load(SPACY_MODEL, disable=['ner'])
+    nlp = spacy.load(SPACY_MODEL, disable=["ner"])
     model = KeyedVectors.load_word2vec_format(word_vectors, binary=binary)
 
     return nlp, model
@@ -58,7 +58,7 @@ def _embed(texts: List[str], nlp: spacy.lang, model) -> List[float]:
     # TODO (John): Empty lines lead to empty lists being appended. Figure out how to filter.
     doc_embeddings = []
     docs = nlp.pipe(texts, n_process=-1)
-    for doc in tqdm(docs, total=len(texts), desc='Embedding documents', dynamic_ncols=True):
+    for doc in tqdm(docs, total=len(texts), desc="Embedding documents", dynamic_ncols=True):
         word_embeddings = []
         for token in doc:
             # TODO (John): Smarter way to do this? If I don't find a word I lowercase it and try
@@ -93,12 +93,12 @@ def _save_embeddings_to_disk(output_file: str, embeddings: List[float]) -> None:
     output_file = Path(output_file)
     output_file.parents[0].mkdir(parents=True, exist_ok=True)
 
-    with open(output_file, 'w') as f:
+    with open(output_file, "w") as f:
         # Format the embeddings in JSON lines format
         for embedding in embeddings:
-            json.dump({'doc_embeddings': embedding}, f)
-            f.write('\n')
+            json.dump({"doc_embeddings": embedding}, f)
+            f.write("\n")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     fire.Fire(main)

--- a/scripts/preprocess_20newsgroup.py
+++ b/scripts/preprocess_20newsgroup.py
@@ -8,8 +8,8 @@ import requests
 from sklearn.model_selection import train_test_split
 
 RANDOM_STATE = 42
-TRAIN_URL = 'http://ana.cachopo.org/datasets-for-single-label-text-categorization/20ng-train-all-terms.txt'
-TEST_URL = 'http://ana.cachopo.org/datasets-for-single-label-text-categorization/20ng-test-all-terms.txt'
+TRAIN_URL = "http://ana.cachopo.org/datasets-for-single-label-text-categorization/20ng-train-all-terms.txt"
+TEST_URL = "http://ana.cachopo.org/datasets-for-single-label-text-categorization/20ng-test-all-terms.txt"
 
 random.seed(RANDOM_STATE)
 
@@ -22,60 +22,69 @@ def main(output_dir: str, validation_size: float = 0.10) -> None:
         validation_size (float, optional): Fraction of examples to hold-out from the train set as a
             validation set. Defaults to 0.10.
     """
-    processed_data = {partition: {'x': [], 'y': []} for partition in ['train', 'valid', 'test']}
+    processed_data = {partition: {"x": [], "y": []} for partition in ["train", "valid", "test"]}
 
     # Download the dataset and split it into individual examples
-    twenty_ng_train = requests.get(TRAIN_URL).text.strip().split('\n')
-    twenty_ng_test = requests.get(TEST_URL).text.strip().split('\n')
+    twenty_ng_train = requests.get(TRAIN_URL).text.strip().split("\n")
+    twenty_ng_test = requests.get(TEST_URL).text.strip().split("\n")
 
     # Accumulate the text (x) and the labels (y)
     for ex in twenty_ng_train:
-        label, text = ex.split('\t')
-        processed_data['train']['x'].append(text)
-        processed_data['train']['y'].append(label)
+        label, text = ex.split("\t")
+        processed_data["train"]["x"].append(text)
+        processed_data["train"]["y"].append(label)
     for ex in twenty_ng_test:
-        label, text = ex.split('\t')
-        processed_data['test']['x'].append(text)
-        processed_data['test']['y'].append(label)
+        label, text = ex.split("\t")
+        processed_data["test"]["x"].append(text)
+        processed_data["test"]["y"].append(label)
 
     # Create the validation split, stratify by class
-    (processed_data['train']['x'], processed_data['valid']['x'],
-     processed_data['train']['y'], processed_data['valid']['y']) = train_test_split(
-        processed_data['train']['x'], processed_data['train']['y'],
-        test_size=validation_size, random_state=RANDOM_STATE, stratify=processed_data['train']['y']
+    (
+        processed_data["train"]["x"],
+        processed_data["valid"]["x"],
+        processed_data["train"]["y"],
+        processed_data["valid"]["y"],
+    ) = train_test_split(
+        processed_data["train"]["x"],
+        processed_data["train"]["y"],
+        test_size=validation_size,
+        random_state=RANDOM_STATE,
+        stratify=processed_data["train"]["y"],
     )
 
     # Make sure the partition sizes check out
-    assert floor(len(twenty_ng_train) * (1 - validation_size)) \
-        == len(processed_data['train']['x']) \
-        == len(processed_data['train']['y'])
-    assert ceil(len(twenty_ng_train) * validation_size) \
-        == len(processed_data['valid']['x']) \
-        == len(processed_data['valid']['y'])
-    assert len(twenty_ng_test) \
-        == len(processed_data['test']['x']) \
-        == len(processed_data['test']['y'])
+    assert (
+        floor(len(twenty_ng_train) * (1 - validation_size))
+        == len(processed_data["train"]["x"])
+        == len(processed_data["train"]["y"])
+    )
+    assert (
+        ceil(len(twenty_ng_train) * validation_size)
+        == len(processed_data["valid"]["x"])
+        == len(processed_data["valid"]["y"])
+    )
+    assert len(twenty_ng_test) == len(processed_data["test"]["x"]) == len(processed_data["test"]["y"])
 
     print("Processed the 20 Newsgroup dataset. Number of examples:")
     num_processed_examples = 0
     for partition, data in processed_data.items():
-        n = len(data['x'])
+        n = len(data["x"])
         print(f"* {partition}: {n}")
         num_processed_examples += n
     print(f"* total: {num_processed_examples}")
 
     _write_to_disk(output_dir, processed_data)
 
-    print(f'Preprocessed files saved to disk at: {os.path.abspath(output_dir)}')
+    print(f"Preprocessed files saved to disk at: {os.path.abspath(output_dir)}")
 
 
 def _write_to_disk(output_dir: str, processed_data: dict) -> None:
     for partition, data in processed_data.items():
-        with open(os.path.join(output_dir, f'{partition}.txt'), 'w') as f:
-            f.write('\n'.join(data['x']))
-        with open(os.path.join(output_dir, f'{partition}_labels.txt'), 'w') as f:
-            f.write('\n'.join(data['y']))
+        with open(os.path.join(output_dir, f"{partition}.txt"), "w") as f:
+            f.write("\n".join(data["x"]))
+        with open(os.path.join(output_dir, f"{partition}_labels.txt"), "w") as f:
+            f.write("\n".join(data["y"]))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     fire.Fire(main)

--- a/scripts/run_senteval.py
+++ b/scripts/run_senteval.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import absolute_import, division, unicode_literals
 
 import json
@@ -8,12 +9,18 @@ from pathlib import Path
 from typing import Callable, List
 
 import numpy as np
+import torch
 import typer
 
-from allennlp.common import Params
+# TODO (John): I only need this for the sanitize method. Would be better if this was NOT a dependency for people
+# who don't want to evaluate AllenNLP models.
 from allennlp.common import util as common_util
-from allennlp.data import DatasetReader
-from allennlp.models.model import Model
+
+try:
+    from apex import amp
+except ImportError:
+    amp = None
+
 
 app = typer.Typer()
 
@@ -21,108 +28,354 @@ app = typer.Typer()
 logger = logging.getLogger(__name__)
 
 # TODO (John): This should be user configurable
-TRANSFER_TASKS = ['STS12', 'STS13', 'STS14', 'STS15', 'STS16',
-                  'MR', 'CR', 'MPQA', 'SUBJ', 'SST2', 'SST5', 'TREC', 'MRPC',
-                  'SICKEntailment', 'SICKRelatedness', 'STSBenchmark',
-                  'Length', 'WordContent', 'Depth', 'TopConstituents',
-                  'BigramShift', 'Tense', 'SubjNumber', 'ObjNumber',
-                  'OddManOut', 'CoordinationInversion']
+TRANSFER_TASKS = [
+    "STS12",
+    "STS13",
+    "STS14",
+    "STS15",
+    "STS16",
+    "MR",
+    "CR",
+    "MPQA",
+    "SUBJ",
+    "SST2",
+    "SST5",
+    "TREC",
+    "MRPC",
+    "SICKEntailment",
+    "SICKRelatedness",
+    "STSBenchmark",
+    "Length",
+    "WordContent",
+    "Depth",
+    "TopConstituents",
+    "BigramShift",
+    "Tense",
+    "SubjNumber",
+    "ObjNumber",
+    "OddManOut",
+    "CoordinationInversion",
+]
 
 # Emoji's used in typer.secho calls
 # See: https://github.com/carpedm20/emoji/blob/master/emoji/unicode_codes.py
-WARNING = '\U000026A0'
-SUCCESS = '\U00002705'
-RUNNING = '\U000023F3'
-SAVING = '\U0001F4BE'
+WARNING = "\U000026A0"
+SUCCESS = "\U00002705"
+RUNNING = "\U000023F3"
+SAVING = "\U0001F4BE"
+FAST = "\U0001F3C3"
+SCORE = "\U0001F4CB"
+
+
+def _get_device(cuda_device):
+    """Return a `torch.cuda` device if `torch.cuda.is_available()` and `cuda_device` is non-negative. Otherwise
+    returns a `torch.cpu` device.
+    """
+    if cuda_device != -1 and torch.cuda.is_available():
+        device = torch.device("cuda")
+    else:
+        device = torch.device("cpu")
+    return device
+
+
+def _compute_aggregate_score(results):
+    """Computes a simple aggregate score score for the given SentEval `results`.
+    """
+    aggregate_score = 0
+    for task, scores in results.items():
+        if task == "STSBenchmark" or task == "SICKRelatedness":
+            aggregate_score += scores["spearman"] * 100
+        elif task.startswith("STS"):
+            aggregate_score += scores["all"]["spearman"]["mean"] * 100
+        elif "acc" in scores:
+            aggregate_score += scores["acc"]
+        else:
+            raise ValueError(f'Found an unexpected field in results, "{task}".')
+    return aggregate_score / len(results)
+
+
+def _setup_mixed_precision_with_amp(model: torch.nn.Module, opt_level: str = None):
+    """Wraps a model with NVIDIAs amp API for mixed-precision inference. This is a no-op if `opt_level is None`.
+    """
+
+    if opt_level is not None:
+        if amp is None:
+            raise ValueError(
+                (
+                    "Apex not installed but opt_level was provided. Please install NVIDIA's Apex to enable"
+                    " automatic mixed precision (AMP) for inference. See: https://github.com/NVIDIA/apex."
+                )
+            )
+
+        model = amp.initialize(model, opt_level=opt_level)
+        typer.secho(
+            f'{FAST} Using mixed-precision with "opt_level={opt_level}".', fg=typer.colors.WHITE, bold=True
+        )
+
+    return model
+
+
+def _pad_sequences(sequences, pad_token):
+    """Pads the elements of `sequences` with `pad_token` up to the longest sequence length."""
+    max_len = len(max(sequences, key=len))
+    padded_sequences = [seq + ([pad_token] * (max_len - len(seq))) for seq in sequences]
+    return padded_sequences
 
 
 def _setup_senteval(path_to_senteval: str, prototyping_config: bool = False, verbose: bool = False) -> None:
     if verbose:
-        logging.basicConfig(format='%(asctime)s : %(message)s', level=logging.DEBUG)
+        logging.basicConfig(format="%(asctime)s : %(message)s", level=logging.DEBUG)
 
     # Set params for SentEval
     # See: https://github.com/facebookresearch/SentEval#senteval-parameters for explanation of the protoype config
-    path_to_data = os.path.join(path_to_senteval, 'data')
+    path_to_data = os.path.join(path_to_senteval, "data")
     if prototyping_config:
         typer.secho(
-            (f"{WARNING} Using prototyping config. Pass --no-prototyping-config to get results comparable to the"
-             " literature."),
+            (
+                f"{WARNING} Using prototyping config. Pass --no-prototyping-config to get results comparable to"
+                "  the literature."
+            ),
             fg=typer.colors.YELLOW,
-            bold=True
+            bold=True,
         )
-        params_senteval = {'task_path': path_to_data, 'usepytorch': True, 'kfold': 5}
-        params_senteval['classifier'] = {'nhid': 0, 'optim': 'rmsprop', 'batch_size': 128,
-                                         'tenacity': 3, 'epoch_size': 2}
+        params_senteval = {"task_path": path_to_data, "usepytorch": True, "kfold": 5}
+        params_senteval["classifier"] = {
+            "nhid": 0,
+            "optim": "rmsprop",
+            "batch_size": 128,
+            "tenacity": 3,
+            "epoch_size": 2,
+        }
     else:
-        params_senteval = {'task_path': path_to_data, 'usepytorch': True, 'kfold': 10}
-        params_senteval['classifier'] = {'nhid': 0, 'optim': 'adam', 'batch_size': 64,
-                                         'tenacity': 5, 'epoch_size': 4}
+        params_senteval = {"task_path": path_to_data, "usepytorch": True, "kfold": 10}
+        params_senteval["classifier"] = {
+            "nhid": 0,
+            "optim": "adam",
+            "batch_size": 64,
+            "tenacity": 5,
+            "epoch_size": 4,
+        }
 
     return params_senteval
 
 
 def _run_senteval(
-    params,
-    path_to_senteval: str,
-    batcher: Callable,
-    prepare: Callable,
-    output_filepath: str = None
+    params, path_to_senteval: str, batcher: Callable, prepare: Callable, output_filepath: str = None
 ) -> None:
     sys.path.insert(0, path_to_senteval)
     import senteval
 
     typer.secho(
-        f"{SUCCESS} SentEval repository and transfer task data loaded successfully.",
+        f"{SUCCESS}  SentEval repository and transfer task data loaded successfully.",
         fg=typer.colors.GREEN,
-        bold=True
+        bold=True,
     )
-    typer.secho(f"{RUNNING} Running evaluation. This may take a while!", fg=typer.colors.WHITE, bold=True)
+    typer.secho(f"{RUNNING}  Running evaluation. This may take a while!", fg=typer.colors.WHITE, bold=True)
 
     se = senteval.engine.SE(params, batcher, prepare)
     results = se.eval(TRANSFER_TASKS)
-    typer.secho(f"{SUCCESS} Evaluation complete!", fg=typer.colors.GREEN, bold=True)
+    typer.secho(f"{SUCCESS}  Evaluation complete!", fg=typer.colors.GREEN, bold=True)
+
+    score = _compute_aggregate_score(results)
+    typer.secho(f"{SCORE}  Aggregate score: {score:.2f}%", fg=typer.colors.WHITE, bold=True)
 
     if output_filepath is not None:
+        # Create the directory path if it doesn't exist
+        output_filepath = Path(output_filepath)
+        output_filepath.parents[0].mkdir(parents=True, exist_ok=True)
         with open(output_filepath, "w") as fp:
             json.dump(common_util.sanitize(results), fp, indent=2)
-        typer.secho(f"{SAVING} Results saved to: {output_filepath}", fg=typer.colors.WHITE, bold=True)
+        typer.secho(f"{SAVING}  Results saved to: {output_filepath}", fg=typer.colors.WHITE, bold=True)
     else:
         typer.secho(
             f"{WARNING} --output_filepath was not provided, printing results to console instead.",
             fg=typer.colors.YELLOW,
-            bold=True
+            bold=True,
         )
         print(results)
+    return
 
 
 @app.command()
-def allennlp(
+def aggregate_score(path_to_results: str):
+    with open(path_to_results, "r") as f:
+        results = json.load(f)
+    score = _compute_aggregate_score(results)
+    typer.secho(f"{SCORE}  Aggregate score: {score:.2f}%", fg=typer.colors.WHITE, bold=True)
+    return score
+
+
+@app.command()
+def bow() -> None:
+    """Evaluates pre-trained word vectors against the SentEval benchmark.
+    """
+    raise NotImplementedError
+
+
+@app.command()
+def transformers(
     path_to_senteval: str,
-    path_to_allennlp_archive: str,
+    pretrained_model_name_or_path: str,
     output_filepath: str = None,
     prototyping_config: bool = False,
-    embeddings_field: str = "embeddings",
+    mean_pool: bool = False,
     cuda_device: int = -1,
-    overrides: str = "",
-    include_package: List[str] = None,
-    verbose: bool = False
+    opt_level: str = None,
+    verbose: bool = False,
 ) -> None:
-    """Evaluates a trained AllenNLP model against the SentEval benchmark.
+    """Evaluates a pre-trained model from the Transformers library against the SentEval benchmark.
     """
+
+    # This prevents import errors when a user doesn't have the dependencies for this command installed
+    from transformers import AutoModel, AutoTokenizer
 
     # SentEval prepare and batcher
     def prepare(params, samples):
         return
 
     def batcher(params, batch):
-        instances = [params.reader.text_to_instance(" ".join(tokenized_text)) for tokenized_text in batch]
-        outputs = params.model.forward_on_instances(instances)
-        embeddings = np.vstack([output[embeddings_field] for output in outputs])
+        # Re-tokenize the input text using the pre-trained tokenizer
+        batch = [tokenizer.encode(" ".join(tokens)) for tokens in batch]
+        batch = _pad_sequences(batch, tokenizer.pad_token_id)
 
+        # To embed with transformers, we (minimally) need the input ids and the attention masks.
+        input_ids = torch.as_tensor(batch, device=params.device)
+        attention_masks = torch.where(
+            input_ids == params.tokenizer.pad_token_id, torch.zeros_like(input_ids), torch.ones_like(input_ids)
+        )
+
+        with torch.no_grad():
+            sequence_output, pooled_output = params.model(input_ids=input_ids, attention_mask=attention_masks)
+
+        # If mean_pool, we take the average of the token-level embeddings, accounting for pads.
+        # Otherwise, we take the pooled output for this specific model, which is typically the linear projection
+        # of a special tokens embedding, like [CLS] or <s>, which is prepended to the input during tokenization.
+        if mean_pool:
+            embeddings = torch.sum(sequence_output * attention_masks.unsqueeze(-1), dim=1) / torch.clamp(
+                torch.sum(attention_masks, dim=1, keepdims=True), min=1e-9
+            )
+        else:
+            embeddings = pooled_output
+
+        embeddings = embeddings.cpu().numpy()
         return embeddings
+
+    # Determine the torch device
+    device = _get_device(cuda_device)
+
+    # Load the Transformers tokenizer
+    tokenizer = AutoTokenizer.from_pretrained(pretrained_model_name_or_path)
+    typer.secho(
+        f'{SUCCESS}  Tokenizer "{pretrained_model_name_or_path}" from Transformers loaded successfully.',
+        fg=typer.colors.GREEN,
+        bold=True,
+    )
+
+    # Load the Transformers model
+    model = AutoModel.from_pretrained(pretrained_model_name_or_path).to(device)
+    model.eval()
+    typer.secho(
+        f'{SUCCESS}  Model "{pretrained_model_name_or_path}" from Transformers loaded successfully.',
+        fg=typer.colors.GREEN,
+        bold=True,
+    )
+
+    # Used mixed-precision to speed up inference
+    model = _setup_mixed_precision_with_amp(model, opt_level)
 
     # Performs a few setup steps and returns the SentEval params
     params_senteval = _setup_senteval(path_to_senteval, prototyping_config, verbose)
+    params_senteval["tokenizer"] = tokenizer
+    params_senteval["model"] = model
+    params_senteval["device"] = device
+    _run_senteval(params_senteval, path_to_senteval, batcher, prepare, output_filepath)
+
+    return
+
+
+@app.command()
+def sentence_transformers(
+    path_to_senteval: str,
+    pretrained_model_name_or_path: str,
+    output_filepath: str = None,
+    prototyping_config: bool = False,
+    cuda_device: int = -1,
+    opt_level: str = None,
+    verbose: bool = False,
+) -> None:
+    """Evaluates a pre-trained model from the Sentence Transformers library against the SentEval benchmark.
+    """
+
+    # This prevents import errors when a user doesn't have the dependencies for this command installed
+    from sentence_transformers import SentenceTransformer
+
+    # SentEval prepare and batcher
+    def prepare(params, samples):
+        return
+
+    def batcher(params, batch):
+        # Sentence Transformers API expects un-tokenized sentences.
+        batch = [" ".join(tokens) for tokens in batch]
+        with torch.no_grad():
+            embeddings = params.model.encode(batch)
+        embeddings = np.vstack(embeddings)
+        return embeddings
+
+    # Determine the torch device
+    device = _get_device(cuda_device)
+
+    # Load the Sentence Transformers tokenizer
+    model = SentenceTransformer(pretrained_model_name_or_path, device=device)
+    model.eval()
+    typer.secho(
+        f'{SUCCESS}  Model "{pretrained_model_name_or_path}" from Sentence Transformers loaded successfully.',
+        fg=typer.colors.GREEN,
+        bold=True,
+    )
+    # Used mixed-precision to speed up inference
+    model = _setup_mixed_precision_with_amp(model, opt_level)
+
+    # Performs a few setup steps and returns the SentEval params
+    params_senteval = _setup_senteval(path_to_senteval, prototyping_config, verbose)
+    params_senteval["model"] = model
+    _run_senteval(params_senteval, path_to_senteval, batcher, prepare, output_filepath)
+
+    return
+
+
+@app.command()
+def allennlp(
+    path_to_senteval: str,
+    path_to_allennlp_archive: str,
+    predictor_name: str,
+    output_filepath: str = None,
+    prototyping_config: bool = False,
+    embeddings_field: str = "embeddings",
+    cuda_device: int = -1,
+    include_package: List[str] = None,
+    verbose: bool = False,
+) -> None:
+    """Evaluates a trained AllenNLP model against the SentEval benchmark.
+    """
+
+    # This prevents import errors when a user doesn't have the dependencies for this command installed
+    from allennlp.models.archival import load_archive
+    from allennlp.predictors import Predictor
+
+    # SentEval prepare and batcher
+    def prepare(params, samples):
+        return
+
+    def batcher(params, batch):
+        with torch.no_grad():
+            # Re-tokenize the input text using the tokenizer of the dataset reader
+            inputs = [{"text": " ".join(tokens)} for tokens in batch]
+            outputs = params.predictor.predict_batch_json(inputs)
+        # AllenNLP models return a dictionary, so we need to access the embeddings with the given key.
+        embeddings = [output[embeddings_field] for output in outputs]
+
+        embeddings = np.vstack(embeddings)
+        return embeddings
 
     # This allows us to import custom dataset readers and models that may exist in the AllenNLP archive.
     # See: https://github.com/allenai/allennlp/blob/e19605aae05eff60b0f41dc521b9787867fa58dd/allennlp/commands/train.py#L404
@@ -130,39 +383,20 @@ def allennlp(
     for package_name in include_package:
         common_util.import_module_and_submodules(package_name)
 
-    serialization_dir = Path(path_to_allennlp_archive)
-    config_filepath = serialization_dir / 'config.json'
-    allennlp_params = Params.from_file(config_filepath, overrides)
-    dataset_reader_params = allennlp_params["dataset_reader"]
+    # Load the archived Model
+    archive = load_archive(path_to_allennlp_archive)
+    predictor = Predictor.from_archive(archive, predictor_name)
+    typer.secho(f"{SUCCESS}  Model from AllenNLP archive loaded successfully.", fg=typer.colors.GREEN, bold=True)
 
-    # Load the archived DatasetReader
-    reader = DatasetReader.from_params(dataset_reader_params)
-    typer.secho(
-        f"{SUCCESS} DatasetReader from AllenNLP archive loaded successfully.",
-        fg=typer.colors.GREEN,
-        bold=True
-    )
+    # Used mixed-precision to speed up inference
+    # model = _setup_mixed_precision_with_amp(model, allennlp_params["trainer"]["opt_level"])
 
-    # Load the archived AllenNLP model
-    model = Model.load(allennlp_params, serialization_dir=serialization_dir, cuda_device=cuda_device).eval()
-    typer.secho(f"{SUCCESS} Model from AllenNLP archive loaded successfully", fg=typer.colors.GREEN, bold=True)
-
-    params_senteval['reader'] = reader
-    params_senteval['model'] = model
-
+    # Performs a few setup steps and returns the SentEval params
+    params_senteval = _setup_senteval(path_to_senteval, prototyping_config, verbose)
+    params_senteval["predictor"] = predictor
     _run_senteval(params_senteval, path_to_senteval, batcher, prepare, output_filepath)
 
     return
-
-
-@app.command()
-def bow() -> None:
-    raise NotImplementedError
-
-
-@app.command()
-def transformers() -> None:
-    raise NotImplementedError
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,8 @@ setuptools.setup(
     install_requires=[
         "allennlp>=0.9.1",
         "torch>=1.4.0",
-        "pytorch-metric-learning>=0.9.77",
-        "typer>=0.0.8",
+        "pytorch-metric-learning>=0.9.78",
+        "typer>=0.1.0",
     ],
     extras_require={"dev": ["black", "flake8", "pytest"]},
 )

--- a/t2t/predictors/__init__.py
+++ b/t2t/predictors/__init__.py
@@ -1,1 +1,2 @@
+from t2t.predictors.contrastive_predictor import no_sample
 from t2t.predictors.contrastive_predictor import ContrastivePredictor

--- a/t2t/predictors/__init__.py
+++ b/t2t/predictors/__init__.py
@@ -1,0 +1,1 @@
+from t2t.predictors.contrastive_predictor import ContrastivePredictor

--- a/t2t/predictors/contrastive_predictor.py
+++ b/t2t/predictors/contrastive_predictor.py
@@ -1,0 +1,31 @@
+from overrides import overrides
+
+from allennlp.common.util import JsonDict
+from allennlp.data import DatasetReader, Instance
+from allennlp.predictors.predictor import Predictor
+
+
+@Predictor.register("contrastive")
+class ContrastivePredictor(Predictor):
+    """Predictor wrapper for the ContrastiveTextEncoder"""
+
+    @overrides
+    def _json_to_instance(self, json_dict: JsonDict) -> Instance:
+        text = json_dict["text"]
+        # Context manager ensures that the sample_spans property of our DatasetReader is False
+        with no_sample(self._dataset_reader):
+            return self._dataset_reader.text_to_instance(text=text)
+
+
+class no_sample:
+    """Context manager that disables sampling of spans for the given `dataset_reader`."""
+
+    def __init__(self, dataset_reader: DatasetReader):
+        self.dataset_reader = dataset_reader
+        self.prev = self.dataset_reader.sample_spans
+
+    def __enter__(self):
+        self.dataset_reader.sample_spans = False
+
+    def __exit__(self, *args):
+        self.dataset_reader.sample_spans = self.prev

--- a/t2t/tests/predictors/test_contrastive_predictor.py
+++ b/t2t/tests/predictors/test_contrastive_predictor.py
@@ -1,0 +1,14 @@
+from t2t.data.dataset_readers import ContrastiveDatasetReader
+from t2t.predictors import no_sample
+
+
+class TestContrastivePredictor:
+    def test_no_sample_context_manager(self):
+        dataset_readers = ContrastiveDatasetReader(sample_spans=True)
+
+        # While in the scope of the context manager, sample_spans should be false.
+        # After existing the context manger, it should return to True.
+        with no_sample(dataset_readers):
+            assert not dataset_readers.sample_spans
+
+        assert dataset_readers._sample_spans


### PR DESCRIPTION
# Overview

This PR adds a `predictor` for `ContrastiveTextEncoder`. Broadly speaking this helps standardize the process of making predictions with the model (e.g. in `run_senteval.py`). In the future, we can add an `embed` method to make it easier to use the model, like so:

```python
sentence_embedding = model.embed("Some text here")
```

I also added a context manager that will set the `sample_spans` attribute of the `ContrastiveDatasetReader` to `False` when making predictions.

```python
from t2t.predictors import no_sample

with no_sample(dataset_reader):
    # in here, dataset_reader.sample_spans is False!
    pass
# out here, it returns to whatever it was before we entered the context manager
```