### PR TITLE
Register Pytorch Metric Learning Loss

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        git clone https://github.com/allenai/allennlp.git
+        cd allennlp
+        pip install --editable .
+        cd ../
         pip install -e ".[dev]"
     - name: Format code with black
       run: |

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setuptools.setup(
     ],
     python_requires=">=3.7",
     install_requires=[
-        "allennlp>=0.9.1",
         "torch>=1.4.0",
         "pytorch-metric-learning>=0.9.79",
         "typer>=0.1.0",

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setuptools.setup(
     install_requires=[
         "allennlp>=0.9.1",
         "torch>=1.4.0",
-        "pytorch-metric-learning>=0.9.78",
+        "pytorch-metric-learning>=0.9.79",
         "typer>=0.1.0",
     ],
     extras_require={"dev": ["black", "flake8", "pytest"]},

--- a/t2t/losses/__init__.py
+++ b/t2t/losses/__init__.py
@@ -1,4 +1,5 @@
-from t2t.losses.pytorch_metric_learning_loss import (
+from t2t.losses.pytorch_metric_learning import (
+    CrossBatchMemory,
     NTXentLoss,
     PyTorchMetricLearningLoss,
 )

--- a/t2t/losses/pytorch_metric_learning.py
+++ b/t2t/losses/pytorch_metric_learning.py
@@ -1,19 +1,20 @@
 from typing import List, Tuple
 
 import torch
-from pytorch_metric_learning.losses import NTXentLoss as NTXent
+from pytorch_metric_learning import losses
 
 from allennlp.common import Registrable
+from t2t.miners import PyTorchMetricLearningMiner
 
 
 class PyTorchMetricLearningLoss(Registrable):
     """This class just allows us to implement `Registrable` for PyTorch Metric Learning loss functions.
     Subclasses of this class should also subclass a loss function from PyTorch Metric Learning
-    (see: https://github.com/KevinMusgrave/pytorch-metric-learning), and accept as arguments
-    to the constructor the same arguments that the loss function does, as well as the `BaseMetricLossFunction`
-    (see: https://kevinmusgrave.github.io/pytorch-metric-learning/losses/#basemetriclossfunction).
-    See `NTXentLoss` below as an example.
+    (see: https://kevinmusgrave.github.io/pytorch-metric-learning/losses/), and accept as arguments
+    to the constructor the same arguments that the loss function does. See `NTXentLoss` below for an example.
     """
+
+    default_implementation = "nt_xent"
 
     @classmethod
     def get_embeddings_and_labels(
@@ -45,8 +46,12 @@ class PyTorchMetricLearningLoss(Registrable):
         return embeddings, labels
 
 
-@PyTorchMetricLearningLoss.register("nt-xent")
-class NTXentLoss(PyTorchMetricLearningLoss, NTXent):
+@PyTorchMetricLearningLoss.register("nt_xent")
+class NTXentLoss(PyTorchMetricLearningLoss, losses.NTXentLoss):
+    """Wraps the `NTXentLoss` implementation from Pytorch Metric Learning:
+    (https://kevinmusgrave.github.io/pytorch-metric-learning/losses/#ntxentloss)
+    """
+
     def __init__(
         self,
         temperature: float,
@@ -60,4 +65,23 @@ class NTXentLoss(PyTorchMetricLearningLoss, NTXent):
             normalize_embeddings=normalize_embeddings,
             num_class_per_param=num_class_per_param,
             learnable_param_names=learnable_param_names,
+        )
+
+
+@PyTorchMetricLearningLoss.register("cross_batch_memory")
+class CrossBatchMemory(PyTorchMetricLearningLoss, losses.CrossBatchMemory):
+    """Wraps the `CrossBatchMemory` implementation from Pytorch Metric Learning:
+    (https://kevinmusgrave.github.io/pytorch-metric-learning/losses/#crossbatchmemory)
+    """
+
+    def __init__(
+        self,
+        loss: PyTorchMetricLearningLoss,
+        embedding_size: int,
+        memory_size: int = 1024,
+        miner: PyTorchMetricLearningMiner = None,
+    ) -> None:
+
+        super().__init__(
+            loss=loss, embedding_size=embedding_size, memory_size=memory_size, miner=miner,
         )

--- a/t2t/miners/__init__.py
+++ b/t2t/miners/__init__.py
@@ -1,0 +1,1 @@
+from t2t.miners.pytorch_metric_learning import BatchHardMiner, PyTorchMetricLearningMiner

--- a/t2t/miners/pytorch_metric_learning.py
+++ b/t2t/miners/pytorch_metric_learning.py
@@ -1,0 +1,54 @@
+from pytorch_metric_learning import miners
+
+from allennlp.common import Registrable
+
+
+class PyTorchMetricLearningMiner(Registrable):
+    """This class just allows us to implement `Registrable` for PyTorch Metric Learning miner functions.
+    Subclasses of this class should also subclass a miner function from PyTorch Metric Learning
+    (see: https://kevinmusgrave.github.io/pytorch-metric-learning/miners/), and accept as arguments
+    to the constructor the same arguments that the miner function does. See `MaximumLossMiner` below
+    for an example.
+    """
+
+    default_implementation = "batch_hard"
+
+
+@PyTorchMetricLearningMiner.register("batch_hard")
+class BatchHardMiner(PyTorchMetricLearningMiner, miners.BatchHardMiner):
+    """Wraps the `BatchHardMinder` implementation from Pytorch Metric Learning:
+    (https://kevinmusgrave.github.io/pytorch-metric-learning/miners/#batchhardminer)
+    """
+
+    def __init__(
+        self, use_similarity: bool = True, squared_distances: bool = False, normalize_embeddings: bool = True
+    ) -> None:
+
+        super().__init__(
+            use_similarity=use_similarity,
+            squared_distances=squared_distances,
+            normalize_embeddings=normalize_embeddings,
+        )
+
+
+@PyTorchMetricLearningMiner.register("hdc")
+@PyTorchMetricLearningMiner.register("hard_aware")
+class HDCMiner(PyTorchMetricLearningMiner, miners.HDCMiner):
+    """Wraps the `HDCMiner` implementation from Pytorch Metric Learning:
+    (https://kevinmusgrave.github.io/pytorch-metric-learning/miners/#hdcminer)
+    """
+
+    def __init__(
+        self,
+        filter_percentage: float,
+        use_similarity: bool = True,
+        squared_distances: bool = False,
+        normalize_embeddings: bool = True,
+    ) -> None:
+
+        super().__init__(
+            filter_percentage=filter_percentage,
+            use_similarity=use_similarity,
+            squared_distances=squared_distances,
+            normalize_embeddings=normalize_embeddings,
+        )


### PR DESCRIPTION
# Overview

This PR provides a simple way to wrap the [Pytorch Metric Learning](https://github.com/KevinMusgrave/pytorch-metric-learning) library so that we can use any miner/loss function from it easily within AllenNLP.