### PR TITLE
Add span masking

### DIFF
--- a/t2t/data/dataset_readers/dataset_utils/contrastive_utils.py
+++ b/t2t/data/dataset_readers/dataset_utils/contrastive_utils.py
@@ -1,8 +1,19 @@
+import copy
+from math import floor
 from random import randint
-from typing import Iterable
+from typing import Callable, Iterable, List, Optional
+
+import numpy as np
 
 
-def sample_spans(text: str, num_spans: int, min_span_width: int) -> Iterable[str]:
+def sample_spans(
+    text: str,
+    num_spans: int,
+    min_span_len: int,
+    tokenizer: Optional[Callable] = None,
+    span_masking: bool = False,
+    **kwargs,
+) -> Iterable[str]:
     """Returns a generator that yields random spans from `text`.
 
     # Parameters
@@ -11,35 +22,70 @@ def sample_spans(text: str, num_spans: int, min_span_width: int) -> Iterable[str
         The string to extract spans from.
     num_spans : `int`, required
         The total number of spans to return.
-    min_span_width : `int`, required
+    min_span_len : `int`, required
         The minimum length of spans, after whitespace tokenization, to sample.
+    tokenizer : `Callable`, optional
+        Optional tokenizer to use before sampling spans. If `None`, `text.split()` is used.
+    span_masking : `bool`, optional
+        If True, **kwargs will be passed to `mask_spans`, which will mask random, contiguous subsequences from the
+        sampled spans before they are returned.
     """
 
-    # No need for fancier tokenization here. Whitespace tokenization will suffice to generate spans.
-    tokens = text.split()
-
-    if min_span_width > len(tokens):
+    # Whitespace tokenization makes it much more straightforward to do whole word masking but a user can
+    # also provide their own tokenization scheme if they want.
+    tokens = tokenizer(text) if tokenizer is not None else text.split()
+    num_tokens = len(tokens)
+    if min_span_len > num_tokens:
+        tok_method = "tokenizer(text)" if tokenizer else "text.split()"
         raise ValueError(
-            (
-                f"min_span_width ({min_span_width}) must be less than or equal to len(text.split())"
-                f" ({len(tokens)})."
-            )
+            f"min_span_len ({min_span_len}) must be less than or equal to len({tok_method}) ({num_tokens})."
         )
 
-    sampled = set()
+    for _ in range(num_spans):
+        # 1. Sample span length from a beta distribution, which is skewed towards longer spans.
+        span_length = int(np.random.beta(4, 2) * (num_tokens - min_span_len) + min_span_len)
+        # 2. Sample the start index of the span uniformly
+        start = randint(0, num_tokens - span_length)
+        end = start + span_length
+        # 3. Optionally, perform span masking (or "whole word masking")
+        if span_masking:
+            span = mask_spans(tokens[start:end], **kwargs)
+        else:
+            span = tokens[start:end]
 
-    # TODO (John): There is some probability that this will never complete. Add a check to see if num_spans is
-    # valid.
-    while True:
-        if len(sampled) == num_spans:
+        yield " ".join(span)
+
+
+def mask_spans(
+    tokens: List[str], mask_token: str, masking_budget: int = 0.15, max_span_len: int = 10, p: float = 0.2
+) -> List[str]:
+    """Implements a masking procedure similar to: "SpanBERT: Improving Pre-training by Representing and Predicting
+    Spans". In particular, the default masking budget, minimum span length to mask, and p parameter of the
+    geometric distribution to sample from are all taken from SpanBERT. For now, we do NOT replace 10% tokens with
+    random tokens. See: https://arxiv.org/abs/1907.10529 for more details.
+    """
+    tokens = copy.deepcopy(tokens)  # avoid modifying the incoming text in place
+    num_tokens = len(tokens)
+
+    if max_span_len > num_tokens:
+        raise ValueError(
+            (f"max_span_len ({max_span_len}) must be less than or equal to len(text.split())" f" ({num_tokens}).")
+        )
+
+    budget = 0  # percent of words to be masked
+    while budget < masking_budget:
+        # 1. Determine what span lengths are within our budget. If the budget is spent, early-exit
+        len_within_budget = floor(num_tokens * (masking_budget - budget))
+        if len_within_budget < 1:
             break
+        # 2. Sample span length from a geometric distribution, which is skewed towards short spans.
+        # mean(span_length) = 3.8
+        span_length = min(len_within_budget, np.random.geometric(p=p), max_span_len)
+        # 3. Sample the start index of the span uniformly
+        start = randint(0, num_tokens - span_length)
+        end = start + span_length
+        # 4. Mask the sampled span with the given mask token and update the budget
+        tokens[start:end] = [mask_token] * span_length
+        budget += span_length / num_tokens
 
-        start = randint(0, len(tokens) - min_span_width)
-        end = randint(max(start + min_span_width, len(tokens)), len(tokens))
-
-        # Never sample identical spans
-        if (start, end) in sampled:
-            continue
-        sampled.add((start, end))
-
-        yield " ".join(tokens[start:end])
+    return tokens

--- a/t2t/predictors/contrastive_predictor.py
+++ b/t2t/predictors/contrastive_predictor.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 from overrides import overrides
 
 from allennlp.common.util import JsonDict
@@ -17,15 +19,10 @@ class ContrastivePredictor(Predictor):
             return self._dataset_reader.text_to_instance(text=text)
 
 
-class no_sample:
+@contextmanager
+def no_sample(dataset_reader: DatasetReader):
     """Context manager that disables sampling of spans for the given `dataset_reader`."""
-
-    def __init__(self, dataset_reader: DatasetReader):
-        self.dataset_reader = dataset_reader
-        self.prev = self.dataset_reader.sample_spans
-
-    def __enter__(self):
-        self.dataset_reader.sample_spans = False
-
-    def __exit__(self, *args):
-        self.dataset_reader.sample_spans = self.prev
+    prev = dataset_reader
+    dataset_reader.sample_spans = False
+    yield dataset_reader
+    dataset_reader.sample_spans = prev

--- a/t2t/tests/data/dataset_readers/dataset_utils/test_contrastive_utils.py
+++ b/t2t/tests/data/dataset_readers/dataset_utils/test_contrastive_utils.py
@@ -5,22 +5,44 @@ import pytest
 class TestContrastiveUtils:
     def test_sample_spans_returns_valid_spans(self):
         num_spans = 5
-        min_span_width = 5
+        min_span_len = 5
         sentence = "They may take our lives, but they'll never take our freedom!"
 
-        spans = list(contrastive_utils.sample_spans(sentence, num_spans, min_span_width))
+        spans = list(contrastive_utils.sample_spans(sentence, num_spans, min_span_len))
         assert len(spans) == num_spans
 
         for span in spans:
             assert len(span) <= len(sentence)
-            assert len(span) >= min_span_width
+            assert len(span) >= min_span_len
             assert " ".join(span) in " ".join(sentence)
 
-    def test_sample_spans_raises_error_for_invalid_min_span_width(self):
+    def test_sample_spans_raises_error_for_invalid_min_span_len(self):
         num_spans = 5
         sentence = "They may take our lives, but they'll never take our freedom!"
 
-        min_span_width = len(sentence) + 1  # This is guaranteed to be invalid
+        min_span_len = len(sentence) + 1  # This is guaranteed to be invalid
 
         with pytest.raises(ValueError):
-            next(contrastive_utils.sample_spans(sentence, num_spans, min_span_width))
+            next(contrastive_utils.sample_spans(sentence, num_spans, min_span_len))
+
+    def test_mask_spans(self):
+        tokens = "They may take our lives, but they'll never take our freedom!".split()
+        mask_token = "[MASK]"
+        masking_budget = 0.15
+        max_span_len = 10
+        p = 0.2
+
+        masked_tokens = contrastive_utils.mask_spans(tokens, mask_token, masking_budget, max_span_len, p)
+
+        # Check that the number of tokens did not change
+        assert len(masked_tokens) == len(tokens)
+        # Check that the % of masked tokens is within the budget
+        assert masked_tokens.count(mask_token) / len(tokens) <= masking_budget
+
+    def test_mask_spans_value_error(self):
+        text = "They may take our lives, but they'll never take our freedom!".split()
+        mask_token = "[MASK]"
+        max_span_len = len(text) + 1  # This is guaranteed to be invalid
+
+        with pytest.raises(ValueError):
+            contrastive_utils.mask_spans(text, mask_token, max_span_len=max_span_len)


### PR DESCRIPTION
# Overview

This PR adds span masking, which happens in many (maybe all?) of the sentence-level pretext tasks used when pre-training transformers. The particular algorithm I followed was from SpanBERT.

I ran some quick experiments and found this to actually _worsen_ performance, so I will make it false by default. It may make for an interesting ablation in the paper, however.