### PR TITLE
Add masked language modelling

### DIFF
--- a/t2t/data/dataset_readers/contrastive.py
+++ b/t2t/data/dataset_readers/contrastive.py
@@ -5,13 +5,12 @@ from typing import Dict, Iterable, List, Optional
 import torch.distributed as dist
 from overrides import overrides
 
-from allennlp.common.checks import ConfigurationError
 from allennlp.common.file_utils import cached_path
 from allennlp.data.dataset_readers import DatasetReader
 from allennlp.data.fields import Field, ListField, TextField
 from allennlp.data.instance import Instance
 from allennlp.data.token_indexers import SingleIdTokenIndexer, TokenIndexer
-from allennlp.data.tokenizers import SpacyTokenizer, Tokenizer, PretrainedTransformerTokenizer
+from allennlp.data.tokenizers import SpacyTokenizer, Tokenizer
 from t2t.data.dataset_readers.dataset_utils.contrastive_utils import sample_spans
 
 logger = logging.getLogger(__name__)
@@ -54,23 +53,6 @@ class ContrastiveDatasetReader(DatasetReader):
         self._token_indexers = token_indexers or {"tokens": SingleIdTokenIndexer()}
         self._sample_spans = sample_spans
         self._min_span_len = min_span_len
-        self._span_masking = span_masking
-
-        # If masking spans and tokenizer is an instance of PretrainedTransformerTokenizer, use its mask token.
-        # Otherwise a user will have to provide it. Complain if they dont.
-        # This will only work for PretrainedTransformerTokenizer
-        if self._span_masking:
-            if isinstance(self._tokenizer, PretrainedTransformerTokenizer):
-                self._mask_token = self._tokenizer.tokenizer.mask_token
-            else:
-                if mask_token is None:
-                    raise ConfigurationError(
-                        (
-                            "If span_masking is True and tokenizer is not a PretrainedTransformerTokenizer, then"
-                            " mask_token must be provided."
-                        )
-                    )
-                self._mask_token = mask_token
 
         # HACK (John): I need to temporarily disable user warnings because this objects __len__ function returns
         # 1, which confuses PyTorch.
@@ -134,13 +116,7 @@ class ContrastiveDatasetReader(DatasetReader):
         fields: Dict[str, Field] = {}
         if self._sample_spans:
             spans: List[Field] = []
-            for span in sample_spans(
-                text,
-                num_spans=2,
-                min_span_len=self._min_span_len,
-                span_masking=self._span_masking,
-                mask_token=self._mask_token if self._span_masking else None,
-            ):
+            for span in sample_spans(text, num_spans=2, min_span_len=self._min_span_len,):
                 tokens = self._tokenizer.tokenize(span)
                 spans.append(TextField(tokens, self._token_indexers))
             fields["tokens"] = ListField(spans)

--- a/t2t/data/dataset_readers/dataset_utils/contrastive_utils.py
+++ b/t2t/data/dataset_readers/dataset_utils/contrastive_utils.py
@@ -1,18 +1,11 @@
-import copy
-from math import floor
 from random import randint
-from typing import Callable, Iterable, List, Optional
+from typing import Callable, Iterable, Optional
 
 import numpy as np
 
 
 def sample_spans(
-    text: str,
-    num_spans: int,
-    min_span_len: int,
-    tokenizer: Optional[Callable] = None,
-    span_masking: bool = False,
-    **kwargs,
+    text: str, num_spans: int, min_span_len: int, tokenizer: Optional[Callable] = None, **kwargs,
 ) -> Iterable[str]:
     """Returns a generator that yields random spans from `text`.
 
@@ -26,9 +19,6 @@ def sample_spans(
         The minimum length of spans, after whitespace tokenization, to sample.
     tokenizer : `Callable`, optional
         Optional tokenizer to use before sampling spans. If `None`, `text.split()` is used.
-    span_masking : `bool`, optional
-        If True, **kwargs will be passed to `mask_spans`, which will mask random, contiguous subsequences from the
-        sampled spans before they are returned.
     """
 
     # Whitespace tokenization makes it much more straightforward to do whole word masking but a user can
@@ -47,45 +37,5 @@ def sample_spans(
         # 2. Sample the start index of the span uniformly
         start = randint(0, num_tokens - span_length)
         end = start + span_length
-        # 3. Optionally, perform span masking (or "whole word masking")
-        if span_masking:
-            span = mask_spans(tokens[start:end], **kwargs)
-        else:
-            span = tokens[start:end]
 
-        yield " ".join(span)
-
-
-def mask_spans(
-    tokens: List[str], mask_token: str, masking_budget: int = 0.15, max_span_len: int = 10, p: float = 0.2
-) -> List[str]:
-    """Implements a masking procedure similar to: "SpanBERT: Improving Pre-training by Representing and Predicting
-    Spans". In particular, the default masking budget, minimum span length to mask, and p parameter of the
-    geometric distribution to sample from are all taken from SpanBERT. For now, we do NOT replace 10% tokens with
-    random tokens. See: https://arxiv.org/abs/1907.10529 for more details.
-    """
-    tokens = copy.deepcopy(tokens)  # avoid modifying the incoming text in place
-    num_tokens = len(tokens)
-
-    if max_span_len > num_tokens:
-        raise ValueError(
-            (f"max_span_len ({max_span_len}) must be less than or equal to len(text.split())" f" ({num_tokens}).")
-        )
-
-    budget = 0  # percent of words to be masked
-    while budget < masking_budget:
-        # 1. Determine what span lengths are within our budget. If the budget is spent, early-exit
-        len_within_budget = floor(num_tokens * (masking_budget - budget))
-        if len_within_budget < 1:
-            break
-        # 2. Sample span length from a geometric distribution, which is skewed towards short spans.
-        # mean(span_length) = 3.8
-        span_length = min(len_within_budget, np.random.geometric(p=p), max_span_len)
-        # 3. Sample the start index of the span uniformly
-        start = randint(0, num_tokens - span_length)
-        end = start + span_length
-        # 4. Mask the sampled span with the given mask token and update the budget
-        tokens[start:end] = [mask_token] * span_length
-        budget += span_length / num_tokens
-
-    return tokens
+        yield " ".join(tokens[start:end])

--- a/t2t/data/dataset_readers/dataset_utils/masked_lm_utils.py
+++ b/t2t/data/dataset_readers/dataset_utils/masked_lm_utils.py
@@ -1,0 +1,58 @@
+from typing import Tuple
+
+import torch
+from transformers import PreTrainedTokenizer
+
+from allennlp.data import TextFieldTensors
+from allennlp.data.tokenizers import PretrainedTransformerTokenizer
+
+
+def _mask_tokens(
+    inputs: torch.Tensor, tokenizer: PreTrainedTokenizer, mlm_probability: float = 0.15
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Prepare masked tokens inputs/labels for masked language modeling: 80% MASK, 10% random, 10% original.
+    Copied from: https://github.com/huggingface/transformers/blob/master/examples/run_language_modeling.py"""
+
+    if tokenizer.mask_token is None:
+        raise ValueError(
+            (
+                "This tokenizer does not have a mask token which is necessary for masked language modeling. Remove"
+                "the --mlm flag if you want to use this tokenizer."
+            )
+        )
+
+    labels = inputs.clone()
+    # We sample a few tokens in each sequence for masked-LM training (with probability args.mlm_probability
+    # defaults to 0.15 in Bert/RoBERTa)
+    probability_matrix = torch.full(labels.shape, mlm_probability)
+    special_tokens_mask = [
+        tokenizer.get_special_tokens_mask(val, already_has_special_tokens=True) for val in labels.tolist()
+    ]
+    probability_matrix.masked_fill_(torch.tensor(special_tokens_mask, dtype=torch.bool), value=0.0)
+    if tokenizer._pad_token is not None:
+        padding_mask = labels.eq(tokenizer.pad_token_id)
+        probability_matrix.masked_fill_(padding_mask, value=0.0)
+    masked_indices = torch.bernoulli(probability_matrix).bool()
+    labels[~masked_indices] = -100  # We only compute loss on masked tokens
+
+    # 80% of the time, we replace masked input tokens with tokenizer.mask_token ([MASK])
+    indices_replaced = torch.bernoulli(torch.full(labels.shape, 0.8)).bool() & masked_indices
+    inputs[indices_replaced] = tokenizer.convert_tokens_to_ids(tokenizer.mask_token)
+
+    # 10% of the time, we replace masked input tokens with random word
+    indices_random = torch.bernoulli(torch.full(labels.shape, 0.5)).bool() & masked_indices & ~indices_replaced
+    random_words = torch.randint(len(tokenizer), labels.shape, dtype=torch.long)
+    inputs[indices_random] = random_words[indices_random]
+
+    # The rest of the time (10% of the time) we keep the masked input tokens unchanged
+    return inputs, labels
+
+
+def mask_tokens(
+    tokens: TextFieldTensors, tokenizer: PretrainedTransformerTokenizer, mlm_probability: float = 0.15
+) -> TextFieldTensors:
+    device = tokens["tokens"]["token_ids"].device
+    inputs, labels = _mask_tokens(tokens["tokens"]["token_ids"].to("cpu"), tokenizer.tokenizer)
+    tokens["tokens"]["token_ids"] = inputs.to(device)
+    tokens["tokens"]["masked_lm_labels"] = labels.to(device)
+    return tokens

--- a/t2t/modules/text_field_embedders/__init__.py
+++ b/t2t/modules/text_field_embedders/__init__.py
@@ -1,0 +1,1 @@
+from t2t.modules.text_field_embedders.mlm_text_field_embedder import MLMTextFieldEmbedder

--- a/t2t/modules/text_field_embedders/mlm_text_field_embedder.py
+++ b/t2t/modules/text_field_embedders/mlm_text_field_embedder.py
@@ -1,0 +1,65 @@
+import inspect
+from typing import Dict
+
+import torch
+
+from allennlp.common.checks import ConfigurationError
+from allennlp.data import TextFieldTensors
+from allennlp.modules.text_field_embedders import BasicTextFieldEmbedder
+from allennlp.modules.text_field_embedders.text_field_embedder import TextFieldEmbedder
+from allennlp.modules.time_distributed import TimeDistributed
+from allennlp.modules.token_embedders.token_embedder import TokenEmbedder
+
+
+@TextFieldEmbedder.register("mlm")
+class MLMTextFieldEmbedder(BasicTextFieldEmbedder):
+    """
+    This is a a simple wrapper around `BasicTextFieldEmbedder` that accounts for the fact that
+    our custom PretrainedTransformerEmbedderMLM returns a tuple containing the loss for the masked
+    language modelling objective as well as some embedded text. I don't like that we had to modify this class
+    and hope in the future that we can replace it with a model from the https://github.com/allenai/allennlp-models
+    repo.
+    """
+
+    def __init__(self, token_embedders: Dict[str, TokenEmbedder]) -> None:
+        super().__init__(token_embedders)
+
+    def forward(self, text_field_input: TextFieldTensors, num_wrapping_dims: int = 0, **kwargs) -> torch.Tensor:
+        if self._token_embedders.keys() != text_field_input.keys():
+            message = "Mismatched token keys: %s and %s" % (
+                str(self._token_embedders.keys()),
+                str(text_field_input.keys()),
+            )
+            raise ConfigurationError(message)
+
+        embedded_representations = []
+        for key in self._ordered_embedder_keys:
+            # Note: need to use getattr here so that the pytorch voodoo
+            # with submodules works with multiple GPUs.
+            embedder = getattr(self, "token_embedder_{}".format(key))
+            forward_params = inspect.signature(embedder.forward).parameters
+            forward_params_values = {}
+            missing_tensor_args = set()
+            for param in forward_params.keys():
+                if param in kwargs:
+                    forward_params_values[param] = kwargs[param]
+                else:
+                    missing_tensor_args.add(param)
+
+            for _ in range(num_wrapping_dims):
+                embedder = TimeDistributed(embedder)
+
+            tensors: Dict[str, torch.Tensor] = text_field_input[key]
+            if len(tensors) == 1 and len(missing_tensor_args) == 1:
+                # If there's only one tensor argument to the embedder, and we just have one tensor to
+                # embed, we can just pass in that tensor, without requiring a name match.
+                masked_lm_loss, token_vectors = embedder(list(tensors.values())[0], **forward_params_values)
+            else:
+                # If there are multiple tensor arguments, we have to require matching names from the
+                # TokenIndexer.  I don't think there's an easy way around that.
+                masked_lm_loss, token_vectors = embedder(**tensors, **forward_params_values)
+            if token_vectors is not None:
+                # To handle some very rare use cases, we allow the return value of the embedder to
+                # be None; we just skip it in that case.
+                embedded_representations.append(token_vectors)
+        return masked_lm_loss, torch.cat(embedded_representations, dim=-1)

--- a/t2t/modules/token_embedders/__init__.py
+++ b/t2t/modules/token_embedders/__init__.py
@@ -1,0 +1,1 @@
+from t2t.modules.token_embedders.pretrained_transformer_embedder_mlm import PretrainedTransformerEmbedderMLM

--- a/t2t/modules/token_embedders/pretrained_transformer_embedder_mlm.py
+++ b/t2t/modules/token_embedders/pretrained_transformer_embedder_mlm.py
@@ -1,0 +1,107 @@
+from typing import Optional
+
+import torch
+from overrides import overrides
+from transformers import AutoConfig, AutoModelWithLMHead
+
+from allennlp.data.tokenizers import PretrainedTransformerTokenizer
+from allennlp.modules.token_embedders import PretrainedTransformerEmbedder
+from allennlp.modules.token_embedders.token_embedder import TokenEmbedder
+
+
+@TokenEmbedder.register("pretrained_transformer_mlm")
+class PretrainedTransformerEmbedderMLM(PretrainedTransformerEmbedder):
+    """
+    This is a wrapper around `PretrainedTransformerEmbedder` that allows us to train against a masked language
+    modelling objective while we are embedding text. I don't like that we had to modify this class and hope in
+    the future that we can replace it with a model from the https://github.com/allenai/allennlp-models repo.
+    """
+
+    def __init__(self, model_name: str, max_length: int = None, masked_language_modeling: bool = True) -> None:
+        super().__init__(model_name, max_length)
+        self.masked_language_modeling = masked_language_modeling
+        self.tokenizer = PretrainedTransformerTokenizer(model_name)
+        if self.masked_language_modeling:
+            # Models with LM heads may NOT include hidden states in their outputs by default
+            config = AutoConfig.from_pretrained(model_name, output_hidden_states=True)
+            self.transformer_model = AutoModelWithLMHead.from_pretrained(model_name, config=config)
+
+    @overrides
+    def forward(
+        self,
+        token_ids: torch.LongTensor,
+        mask: torch.BoolTensor,
+        type_ids: Optional[torch.LongTensor] = None,
+        segment_concat_mask: Optional[torch.BoolTensor] = None,
+        masked_lm_labels: Optional[torch.LongTensor] = None,
+    ) -> torch.Tensor:  # type: ignore
+        """
+        # Parameters
+
+        token_ids: torch.LongTensor
+            Shape: [
+                batch_size, num_wordpieces if max_length is None else num_segment_concat_wordpieces
+            ].
+            num_segment_concat_wordpieces is num_wordpieces plus special tokens inserted in the
+            middle, e.g. the length of: "[CLS] A B C [SEP] [CLS] D E F [SEP]" (see indexer logic).
+        mask: torch.BoolTensor
+            Shape: [batch_size, num_wordpieces].
+        type_ids: Optional[torch.LongTensor]
+            Shape: [
+                batch_size, num_wordpieces if max_length is None else num_segment_concat_wordpieces
+            ].
+        segment_concat_mask: Optional[torch.BoolTensor]
+            Shape: [batch_size, num_segment_concat_wordpieces].
+        masked_lm_labels: torch.LongTensor
+            Shape: [
+                batch_size, num_wordpieces
+            ].
+
+        # Returns:
+
+        Shape: [batch_size, num_wordpieces, embedding_size].
+        """
+
+        # Some of the huggingface transformers don't support type ids at all and crash when you supply them. For
+        # others, you can supply a tensor of zeros, and if you don't, they act as if you did. There is no practical
+        # difference to the caller, so here we pretend that one case is the same as another case.
+        if type_ids is not None:
+            max_type_id = type_ids.max()
+            if max_type_id == 0:
+                type_ids = None
+            else:
+                if max_type_id >= self._number_of_token_type_embeddings():
+                    raise ValueError("Found type ids too large for the chosen transformer model.")
+                assert token_ids.shape == type_ids.shape
+
+        fold_long_sequences = self._max_length is not None and token_ids.size(1) > self._max_length
+        if fold_long_sequences:
+            batch_size, num_segment_concat_wordpieces = token_ids.size()
+            token_ids, segment_concat_mask, type_ids = self._fold_long_sequences(
+                token_ids, segment_concat_mask, type_ids
+            )
+
+        transformer_mask = segment_concat_mask if self._max_length is not None else mask
+        # Shape: [batch_size, num_wordpieces, embedding_size],
+        # or if self._max_length is not None:
+        # [batch_size * num_segments, self._max_length, embedding_size]
+
+        # We call this with kwargs because some of the huggingface models don't have the token_type_ids parameter
+        # and fail even when it's given as None.
+        # Also, as of transformers v2.5.1, they are taking FloatTensor masks.
+        parameters = {"input_ids": token_ids, "attention_mask": transformer_mask.float()}
+        if type_ids is not None:
+            parameters["token_type_ids"] = type_ids
+        if masked_lm_labels is not None:
+            parameters["masked_lm_labels"] = masked_lm_labels
+            loss, _, embeddings = self.transformer_model(**parameters)
+        else:
+            loss, embeddings = None, self.transformer_model(**parameters)[1]
+        embeddings = embeddings[-1]  # The model returns hidden states from every layer
+
+        if fold_long_sequences:
+            embeddings = self._unfold_long_sequences(
+                embeddings, segment_concat_mask, batch_size, num_segment_concat_wordpieces
+            )
+
+        return loss, embeddings


### PR DESCRIPTION
# Overview

This PR adds a masked language modelling objective to the model. This appears to be the missing ingredient, judging on SentEval performance:

- Sentence Transformers (roberta-base-nli-mean-tokens): 72.69 <-- SOTA, controlling for model size.
- Baseline (distilroberta-mean): 73.76
- Ours: 75.25 ✨ 

Rushing this so @OsvaldN can experiement with MoCo.

