### PR TITLE
Report fine-grained senteval scores

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         pip install -e ".[dev]"
     - name: Format code with black
       run: |
-        black -l 115 t2t
+        black -l 100 t2t
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/scripts/create_contrastive_training_data.py
+++ b/scripts/create_contrastive_training_data.py
@@ -55,7 +55,9 @@ def _generate_positives(anchors: List[str], nlp: spacy.lang):
     positives = []
 
     docs = nlp.pipe(anchors, n_process=-1)
-    for doc in tqdm(docs, total=len(anchors), desc="Generating positive examples", dynamic_ncols=True):
+    for doc in tqdm(
+        docs, total=len(anchors), desc="Generating positive examples", dynamic_ncols=True
+    ):
         # TODO (John): We don't want especially short sentences as they contain little information. As a temporary
         # hack, take the longest sentence from each anchor.
         sents = list(doc.sents)
@@ -67,7 +69,9 @@ def _generate_positives(anchors: List[str], nlp: spacy.lang):
         positives.append(sorted(sents, key=len)[-1].text)
 
     if dropped:
-        print(f"Dropped {dropped}/{len(anchors)} ({dropped/len(anchors):.2%}) anchors with no sentences.")
+        print(
+            f"Dropped {dropped}/{len(anchors)} ({dropped/len(anchors):.2%}) anchors with no sentences."
+        )
 
     return positives
 

--- a/scripts/create_pubmed_citation_triplet_standard.py
+++ b/scripts/create_pubmed_citation_triplet_standard.py
@@ -81,7 +81,9 @@ def main(
     _save_triplets_to_disk(triplets_filepath, triplets)
 
 
-def _load_and_cache_icite_metadata(input_dir: Path, output_dir: Path, cache: bool) -> Dict[str, Dict[str, set]]:
+def _load_and_cache_icite_metadata(
+    input_dir: Path, output_dir: Path, cache: bool
+) -> Dict[str, Dict[str, set]]:
     """"Load citations from disk if they are cached. Otherwise, parse the input dump."
 
     Args:
@@ -129,7 +131,8 @@ def _parse_icite_metadata(
             for line in tqdm(f):
                 contents = json.loads(line)
 
-                # Filter anything that isn't a reasearch article or has less than citation_count_threshold citations
+                # Filter anything that isn't a reasearch article or has less than citation_count_threshold
+                # citations
                 if (not contents["is_research_article"] and research_only) or contents[
                     "citation_count"
                 ] < citation_count_threshold:
@@ -140,9 +143,13 @@ def _parse_icite_metadata(
 
                 # Either references or cited_by can be null
                 if contents["references"] is not None:
-                    citations[pmid].update({str(pmid) for pmid in contents["references"].strip().split()})
+                    citations[pmid].update(
+                        {str(pmid) for pmid in contents["references"].strip().split()}
+                    )
                 if contents["cited_by"] is not None:
-                    citations[pmid].update({str(pmid) for pmid in contents["cited_by"].strip().split()})
+                    citations[pmid].update(
+                        {str(pmid) for pmid in contents["cited_by"].strip().split()}
+                    )
 
     return citations
 
@@ -199,11 +206,17 @@ def _compute_similarity(
         # is less than pos_neg_threshold and the positive examples similarity score exceeds pos_threshold
         # pmid_i is the positive example and pmid_j is the negative example
         if similarity_scores[0] >= pos_threshold:
-            if similarity_scores[1] >= neg_threshold and similarity_scores[1] <= pos_threshold - neg_margin:
+            if (
+                similarity_scores[1] >= neg_threshold
+                and similarity_scores[1] <= pos_threshold - neg_margin
+            ):
                 triplets.append((pmid_i, pmid_j, pmid_k))
         # pmid_j is the positive example and pmid_i is the negative example
         elif similarity_scores[1] >= pos_threshold:
-            if similarity_scores[0] >= neg_threshold and similarity_scores[0] <= pos_threshold - neg_margin:
+            if (
+                similarity_scores[0] >= neg_threshold
+                and similarity_scores[0] <= pos_threshold - neg_margin
+            ):
                 triplets.append((pmid_i, pmid_k, pmid_j))
 
     return triplets

--- a/scripts/embed_with_transformer.py
+++ b/scripts/embed_with_transformer.py
@@ -60,7 +60,9 @@ def _get_device(disable_cuda):
     if not disable_cuda and torch.cuda.is_available():
         device = torch.device("cuda")
         typer.secho(
-            f"{FAST} Using GPU device: {torch.cuda.current_device()}", fg=typer.colors.WHITE, bold=True,
+            f"{FAST} Using GPU device: {torch.cuda.current_device()}",
+            fg=typer.colors.WHITE,
+            bold=True,
         )
     else:
         device = torch.device("cpu")
@@ -91,7 +93,9 @@ def _init_model_and_tokenizer(
         try:
             from apex import amp
         except ImportError:
-            raise ImportError("Please install apex from https://www.github.com/nvidia/apex to use fp16 training.")
+            raise ImportError(
+                "Please install apex from https://www.github.com/nvidia/apex to use fp16 training."
+            )
 
         model = amp.initialize(model, opt_level=opt_level)
 

--- a/scripts/preprocess_20newsgroup.py
+++ b/scripts/preprocess_20newsgroup.py
@@ -8,8 +8,12 @@ import requests
 from sklearn.model_selection import train_test_split
 
 RANDOM_STATE = 42
-TRAIN_URL = "http://ana.cachopo.org/datasets-for-single-label-text-categorization/20ng-train-all-terms.txt"
-TEST_URL = "http://ana.cachopo.org/datasets-for-single-label-text-categorization/20ng-test-all-terms.txt"
+TRAIN_URL = (
+    "http://ana.cachopo.org/datasets-for-single-label-text-categorization/20ng-train-all-terms.txt"
+)
+TEST_URL = (
+    "http://ana.cachopo.org/datasets-for-single-label-text-categorization/20ng-test-all-terms.txt"
+)
 
 random.seed(RANDOM_STATE)
 
@@ -63,7 +67,9 @@ def main(output_dir: str, validation_size: float = 0.10) -> None:
         == len(processed_data["valid"]["x"])
         == len(processed_data["valid"]["y"])
     )
-    assert len(twenty_ng_test) == len(processed_data["test"]["x"]) == len(processed_data["test"]["y"])
+    assert (
+        len(twenty_ng_test) == len(processed_data["test"]["x"]) == len(processed_data["test"]["y"])
+    )
 
     print("Processed the 20 Newsgroup dataset. Number of examples:")
     num_processed_examples = 0

--- a/scripts/run_senteval.py
+++ b/scripts/run_senteval.py
@@ -84,7 +84,11 @@ def _get_device(cuda_device):
 def _compute_aggregate_scores(results):
     """Computes aggregate scores for the dev and test sets in a given SentEval `results`.
     """
-    aggregate_scores = {"downstream": {"dev": 0, "test": 0}, "probing": {"dev": 0, "test": 0}, "all": {}}
+    aggregate_scores = {
+        "downstream": {"dev": 0, "test": 0},
+        "probing": {"dev": 0, "test": 0},
+        "all": {},
+    }
     for task, scores in results.items():
         # Tasks belong to two groups only, "downstream" or "probing"
         task_set = "downstream" if task in DOWNSTREAM_TASKS else "probing"
@@ -144,7 +148,9 @@ def _setup_mixed_precision_with_amp(model: torch.nn.Module, opt_level: str = Non
 
         model = amp.initialize(model, opt_level=opt_level)
         typer.secho(
-            f'{FAST} Using mixed-precision with "opt_level={opt_level}".', fg=typer.colors.WHITE, bold=True
+            f'{FAST} Using mixed-precision with "opt_level={opt_level}".',
+            fg=typer.colors.WHITE,
+            bold=True,
         )
 
     return model
@@ -157,7 +163,9 @@ def _pad_sequences(sequences, pad_token):
     return padded_sequences
 
 
-def _setup_senteval(path_to_senteval: str, prototyping_config: bool = False, verbose: bool = False) -> None:
+def _setup_senteval(
+    path_to_senteval: str, prototyping_config: bool = False, verbose: bool = False
+) -> None:
     if verbose:
         logging.basicConfig(format="%(asctime)s : %(message)s", level=logging.DEBUG)
 
@@ -205,7 +213,9 @@ def _run_senteval(
         fg=typer.colors.GREEN,
         bold=True,
     )
-    typer.secho(f"{RUNNING}  Running evaluation. This may take a while!", fg=typer.colors.WHITE, bold=True)
+    typer.secho(
+        f"{RUNNING}  Running evaluation. This may take a while!", fg=typer.colors.WHITE, bold=True
+    )
 
     se = senteval.engine.SE(params, batcher, prepare)
     results = se.eval(TRANSFER_TASKS)
@@ -213,7 +223,9 @@ def _run_senteval(
 
     aggregate_scores = _compute_aggregate_scores(results)
     typer.secho(
-        f'{SCORE} Aggregate dev score: {aggregate_scores["all"]["dev"]:.2f}%', fg=typer.colors.WHITE, bold=True
+        f'{SCORE} Aggregate dev score: {aggregate_scores["all"]["dev"]:.2f}%',
+        fg=typer.colors.WHITE,
+        bold=True,
     )
 
     if output_filepath is not None:
@@ -226,7 +238,9 @@ def _run_senteval(
             # Add aggregate scores to results dict
             json_safe_results["aggregate_scores"] = aggregate_scores
             json.dump(json_safe_results, fp, indent=2)
-        typer.secho(f"{SAVING}  Results saved to: {output_filepath}", fg=typer.colors.WHITE, bold=True)
+        typer.secho(
+            f"{SAVING}  Results saved to: {output_filepath}", fg=typer.colors.WHITE, bold=True
+        )
     else:
         typer.secho(
             f"{WARNING} --output_filepath was not provided, printing results to console instead.",
@@ -273,7 +287,9 @@ def transformers(
         # To embed with transformers, we (minimally) need the input ids and the attention masks.
         input_ids = torch.as_tensor(batch, device=params.device)
         attention_masks = torch.where(
-            input_ids == params.tokenizer.pad_token_id, torch.zeros_like(input_ids), torch.ones_like(input_ids)
+            input_ids == params.tokenizer.pad_token_id,
+            torch.zeros_like(input_ids),
+            torch.ones_like(input_ids),
         )
 
         with torch.no_grad():
@@ -283,9 +299,9 @@ def transformers(
         # Otherwise, we take the pooled output for this specific model, which is typically the linear projection
         # of a special tokens embedding, like [CLS] or <s>, which is prepended to the input during tokenization.
         if mean_pool:
-            embeddings = torch.sum(sequence_output * attention_masks.unsqueeze(-1), dim=1) / torch.clamp(
-                torch.sum(attention_masks, dim=1, keepdims=True), min=1e-9
-            )
+            embeddings = torch.sum(
+                sequence_output * attention_masks.unsqueeze(-1), dim=1
+            ) / torch.clamp(torch.sum(attention_masks, dim=1, keepdims=True), min=1e-9)
         else:
             # TODO (John): Replace this with the built in pooler from the Transformers lib,
             # as it will check if the last token should be used.
@@ -420,7 +436,11 @@ def allennlp(
     # Load the archived Model
     archive = load_archive(path_to_allennlp_archive)
     predictor = Predictor.from_archive(archive, predictor_name)
-    typer.secho(f"{SUCCESS}  Model from AllenNLP archive loaded successfully.", fg=typer.colors.GREEN, bold=True)
+    typer.secho(
+        f"{SUCCESS}  Model from AllenNLP archive loaded successfully.",
+        fg=typer.colors.GREEN,
+        bold=True,
+    )
 
     # Used mixed-precision to speed up inference
     # model = _setup_mixed_precision_with_amp(model, allennlp_params["trainer"]["opt_level"])

--- a/scripts/run_senteval.py
+++ b/scripts/run_senteval.py
@@ -96,7 +96,6 @@ def _compute_aggregate_scores(results):
         # reported for each task.
         # These two tasks report pearsonr for dev and spearman for test. Not sure why?
         if task == "STSBenchmark" or task == "SICKRelatedness":
-            # For some reason, there is no "devspearman" reported.
             aggregate_scores[task_set]["dev"] += scores["devpearson"] * 100
             aggregate_scores[task_set]["test"] += scores["spearman"] * 100
         # There are no partitions for these tasks as no model is trained on top of the embeddings,
@@ -325,7 +324,7 @@ def transformers(
     model = AutoModel.from_pretrained(pretrained_model_name_or_path).to(device)
     model.eval()
     typer.secho(
-        f'{SUCCESS}  Model "{pretrained_model_name_or_path}" from Transformers loaded successfully.',
+        f'{SUCCESS} Model "{pretrained_model_name_or_path}" from Transformers loaded successfully.',
         fg=typer.colors.GREEN,
         bold=True,
     )
@@ -378,7 +377,7 @@ def sentence_transformers(
     model = SentenceTransformer(pretrained_model_name_or_path, device=device)
     model.eval()
     typer.secho(
-        f'{SUCCESS}  Model "{pretrained_model_name_or_path}" from Sentence Transformers loaded successfully.',
+        f'{SUCCESS} Model "{pretrained_model_name_or_path}" from Sentence Transformers loaded successfully.',
         fg=typer.colors.GREEN,
         bold=True,
     )

--- a/t2t/data/dataset_readers/dataset_utils/masked_lm_utils.py
+++ b/t2t/data/dataset_readers/dataset_utils/masked_lm_utils.py
@@ -26,7 +26,8 @@ def _mask_tokens(
     # defaults to 0.15 in Bert/RoBERTa)
     probability_matrix = torch.full(labels.shape, mlm_probability)
     special_tokens_mask = [
-        tokenizer.get_special_tokens_mask(val, already_has_special_tokens=True) for val in labels.tolist()
+        tokenizer.get_special_tokens_mask(val, already_has_special_tokens=True)
+        for val in labels.tolist()
     ]
     probability_matrix.masked_fill_(torch.tensor(special_tokens_mask, dtype=torch.bool), value=0.0)
     if tokenizer._pad_token is not None:
@@ -40,7 +41,9 @@ def _mask_tokens(
     inputs[indices_replaced] = tokenizer.convert_tokens_to_ids(tokenizer.mask_token)
 
     # 10% of the time, we replace masked input tokens with random word
-    indices_random = torch.bernoulli(torch.full(labels.shape, 0.5)).bool() & masked_indices & ~indices_replaced
+    indices_random = (
+        torch.bernoulli(torch.full(labels.shape, 0.5)).bool() & masked_indices & ~indices_replaced
+    )
     random_words = torch.randint(len(tokenizer), labels.shape, dtype=torch.long)
     inputs[indices_random] = random_words[indices_random]
 
@@ -49,7 +52,9 @@ def _mask_tokens(
 
 
 def mask_tokens(
-    tokens: TextFieldTensors, tokenizer: PretrainedTransformerTokenizer, mlm_probability: float = 0.15
+    tokens: TextFieldTensors,
+    tokenizer: PretrainedTransformerTokenizer,
+    mlm_probability: float = 0.15,
 ) -> TextFieldTensors:
     device = tokens["tokens"]["token_ids"].device
     inputs, labels = _mask_tokens(tokens["tokens"]["token_ids"].to("cpu"), tokenizer.tokenizer)

--- a/t2t/miners/pytorch_metric_learning.py
+++ b/t2t/miners/pytorch_metric_learning.py
@@ -21,7 +21,10 @@ class BatchHardMiner(PyTorchMetricLearningMiner, miners.BatchHardMiner):
     """
 
     def __init__(
-        self, use_similarity: bool = True, squared_distances: bool = False, normalize_embeddings: bool = True
+        self,
+        use_similarity: bool = True,
+        squared_distances: bool = False,
+        normalize_embeddings: bool = True,
     ) -> None:
 
         super().__init__(

--- a/t2t/models/contrastive_text_encoder.py
+++ b/t2t/models/contrastive_text_encoder.py
@@ -3,14 +3,16 @@ from typing import Dict, Optional
 import torch
 
 from allennlp.data import TextFieldTensors, Vocabulary
-from allennlp.data.tokenizers import PretrainedTransformerTokenizer
 from allennlp.models.model import Model
 from allennlp.modules import FeedForward, Seq2SeqEncoder, Seq2VecEncoder, TextFieldEmbedder
 from allennlp.nn import InitializerApplicator
 from allennlp.nn.util import get_text_field_mask
 from t2t.data.dataset_readers.dataset_utils.masked_lm_utils import mask_tokens
 from t2t.losses import PyTorchMetricLearningLoss
-from t2t.models.contrastive_text_encoder_util import all_gather_anchor_positive_pairs, sample_anchor_positive_pairs
+from t2t.models.contrastive_text_encoder_util import (
+    all_gather_anchor_positive_pairs,
+    sample_anchor_positive_pairs,
+)
 
 
 @Model.register("constrastive")
@@ -118,7 +120,9 @@ class ContrastiveTextEncoder(Model):
                 embedded_anchor_text, embedded_positive_text
             )
 
-            embeddings, labels = self._loss.get_embeddings_and_labels(embedded_anchor_text, embedded_positive_text)
+            embeddings, labels = self._loss.get_embeddings_and_labels(
+                embedded_anchor_text, embedded_positive_text
+            )
             contrastive_loss = self._loss(embeddings, labels)
             output_dict["loss"] = contrastive_loss
             if anchor_masked_lm_loss is not None:

--- a/t2t/modules/text_field_embedders/mlm_text_field_embedder.py
+++ b/t2t/modules/text_field_embedders/mlm_text_field_embedder.py
@@ -24,7 +24,9 @@ class MLMTextFieldEmbedder(BasicTextFieldEmbedder):
     def __init__(self, token_embedders: Dict[str, TokenEmbedder]) -> None:
         super().__init__(token_embedders)
 
-    def forward(self, text_field_input: TextFieldTensors, num_wrapping_dims: int = 0, **kwargs) -> torch.Tensor:
+    def forward(
+        self, text_field_input: TextFieldTensors, num_wrapping_dims: int = 0, **kwargs
+    ) -> torch.Tensor:
         if self._token_embedders.keys() != text_field_input.keys():
             message = "Mismatched token keys: %s and %s" % (
                 str(self._token_embedders.keys()),
@@ -53,7 +55,9 @@ class MLMTextFieldEmbedder(BasicTextFieldEmbedder):
             if len(tensors) == 1 and len(missing_tensor_args) == 1:
                 # If there's only one tensor argument to the embedder, and we just have one tensor to
                 # embed, we can just pass in that tensor, without requiring a name match.
-                masked_lm_loss, token_vectors = embedder(list(tensors.values())[0], **forward_params_values)
+                masked_lm_loss, token_vectors = embedder(
+                    list(tensors.values())[0], **forward_params_values
+                )
             else:
                 # If there are multiple tensor arguments, we have to require matching names from the
                 # TokenIndexer.  I don't think there's an easy way around that.

--- a/t2t/modules/token_embedders/__init__.py
+++ b/t2t/modules/token_embedders/__init__.py
@@ -1,1 +1,3 @@
-from t2t.modules.token_embedders.pretrained_transformer_embedder_mlm import PretrainedTransformerEmbedderMLM
+from t2t.modules.token_embedders.pretrained_transformer_embedder_mlm import (
+    PretrainedTransformerEmbedderMLM,
+)

--- a/t2t/modules/token_embedders/pretrained_transformer_embedder_mlm.py
+++ b/t2t/modules/token_embedders/pretrained_transformer_embedder_mlm.py
@@ -17,7 +17,9 @@ class PretrainedTransformerEmbedderMLM(PretrainedTransformerEmbedder):
     the future that we can replace it with a model from the https://github.com/allenai/allennlp-models repo.
     """
 
-    def __init__(self, model_name: str, max_length: int = None, masked_language_modeling: bool = True) -> None:
+    def __init__(
+        self, model_name: str, max_length: int = None, masked_language_modeling: bool = True
+    ) -> None:
         super().__init__(model_name, max_length)
         self.masked_language_modeling = masked_language_modeling
         self.tokenizer = PretrainedTransformerTokenizer(model_name)

--- a/t2t/tests/data/dataset_readers/dataset_utils/test_contrastive_utils.py
+++ b/t2t/tests/data/dataset_readers/dataset_utils/test_contrastive_utils.py
@@ -1,4 +1,4 @@
-from t2t.data.dataset_readers.dataset_utils import contrastive_utils
+from t2t.data.dataset_readers.dataset_utils.contrastive_utils import sample_spans
 import pytest
 
 
@@ -8,7 +8,7 @@ class TestContrastiveUtils:
         min_span_len = 5
         sentence = "They may take our lives, but they'll never take our freedom!"
 
-        spans = list(contrastive_utils.sample_spans(sentence, num_spans, min_span_len))
+        spans = list(sample_spans(sentence, num_spans, min_span_len))
         assert len(spans) == num_spans
 
         for span in spans:
@@ -23,26 +23,4 @@ class TestContrastiveUtils:
         min_span_len = len(sentence) + 1  # This is guaranteed to be invalid
 
         with pytest.raises(ValueError):
-            next(contrastive_utils.sample_spans(sentence, num_spans, min_span_len))
-
-    def test_mask_spans(self):
-        tokens = "They may take our lives, but they'll never take our freedom!".split()
-        mask_token = "[MASK]"
-        masking_budget = 0.15
-        max_span_len = 10
-        p = 0.2
-
-        masked_tokens = contrastive_utils.mask_spans(tokens, mask_token, masking_budget, max_span_len, p)
-
-        # Check that the number of tokens did not change
-        assert len(masked_tokens) == len(tokens)
-        # Check that the % of masked tokens is within the budget
-        assert masked_tokens.count(mask_token) / len(tokens) <= masking_budget
-
-    def test_mask_spans_value_error(self):
-        text = "They may take our lives, but they'll never take our freedom!".split()
-        mask_token = "[MASK]"
-        max_span_len = len(text) + 1  # This is guaranteed to be invalid
-
-        with pytest.raises(ValueError):
-            contrastive_utils.mask_spans(text, mask_token, max_span_len=max_span_len)
+            next(sample_spans(sentence, num_spans, min_span_len))


### PR DESCRIPTION
# Overview

This PR updates the `run_senteval.py` script so that it reports more fine-grained aggregate scores. It now reports aggregate scores from the "downstream" as well as "probing" tasks in addition to "all" tasks. This will help us determine where the contrastive objective is having the biggest effect. This is appended to the `results_senteval.json` returned by the script:

```json
{
  "downstream": {
    "dev": 79.85894459278364,
    "test": 79.55917627773002
  },
  "probing": {
    "dev": 64.57300000000001,
    "test": 64.26400000000001
  },
  "all": {
    "dev": 72.21597229639183,
    "test": 71.91158813886501
  }
}
```

## TODOs:

- ~[x] Why is `run_senteval_sentence_transformers.sh` unaffected by `--verbose` arg?~ Sentence Transformers lib has its own logger which appears to supercede ours?
- [x] Do a final sanity check over the code that computes aggregate scores, this *cannot* be wrong.

## Other changes:

- Drops unit tests for code that no longer exists.
- Changes black line length to 100 and reformats the code base.