### PR TITLE
:bug: Missing cuda devices in call to load_archive

### DIFF
--- a/scripts/run_senteval.py
+++ b/scripts/run_senteval.py
@@ -433,16 +433,13 @@ def allennlp(
         common_util.import_module_and_submodules(package_name)
 
     # Load the archived Model
-    archive = load_archive(path_to_allennlp_archive)
+    archive = load_archive(path_to_allennlp_archive, cuda_device=cuda_device)
     predictor = Predictor.from_archive(archive, predictor_name)
     typer.secho(
         f"{SUCCESS}  Model from AllenNLP archive loaded successfully.",
         fg=typer.colors.GREEN,
         bold=True,
     )
-
-    # Used mixed-precision to speed up inference
-    # model = _setup_mixed_precision_with_amp(model, allennlp_params["trainer"]["opt_level"])
 
     # Performs a few setup steps and returns the SentEval params
     params_senteval = _setup_senteval(path_to_senteval, prototyping_config, verbose)


### PR DESCRIPTION
# Overview

This PR fixes a bug that lead to `run_senteval.py` to always evaluate an `AllenNLP` model on the CPU -- which explains why it took 6 hours.

@OsvaldN, @subercui you guys may want to merge this into your local branches (or fix it manually) so that your evals become much faster. It is a single line of code change.