### PR TITLE
Refactor lib as alllennlp "plugin"

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ For the time being, please install [AllenNLP](https://github.com/allenai/allennl
 
 #### Enabling mixed-precision training
 
-If you want to train with [mixed-precision](https://devblogs.nvidia.com/mixed-precision-training-deep-neural-networks/) (strongly recommended if your GPU supports it), you will need to [install Apex with CUDA and C++ extensions](https://github.com/NVIDIA/apex#quick-start). Once installed, you need only to set `"opt_level"` to `"O1"` in your training [config](configs).
+If you want to train with [mixed-precision](https://devblogs.nvidia.com/mixed-precision-training-deep-neural-networks/) (strongly recommended if your GPU supports it), you will need to [install Apex with CUDA and C++ extensions](https://github.com/NVIDIA/apex#quick-start). Once installed, you need only to set `"opt_level"` to `"O1"` in your training [config](configs), or, equivalently, pass the following flag to `allennlp train`
+
+```bash
+--overrides '{"trainer.opt_level": "O1"}'
+```
 
 ## Usage
 
@@ -51,6 +55,8 @@ allennlp train configs/contrastive.jsonnet \
 ```
 
 During training, models, vocabulary, configuration and log files will be saved to `output`. This can be changed to any path you like.
+
+> We also provide a config for distributed training ([`contrastive_distributed.jsonnet`](configs/contrastive_distributed.jsonnet)).
 
 ### Embedding
 

--- a/allennlp_plugins/t2t/__init__.py
+++ b/allennlp_plugins/t2t/__init__.py
@@ -1,0 +1,1 @@
+import t2t


### PR DESCRIPTION
# Overview

This PR uses AllenNLP's "plugin" system to declare this package as an AllenNLP plugin. I did this at the suggestion of one of their devs, because without it, I was not able to train on multiple GPUs (`ModuleNotFound` error).

## Other changes

- Slightly improve the instructions in the readme on `amp` and distributed training.