### PR TITLE
Fix empty sentence problem in SentEval

### DIFF
--- a/scripts/run_senteval.py
+++ b/scripts/run_senteval.py
@@ -284,7 +284,7 @@ def transformers(
         # with HuggingfFace's tokenizer.
         # I am using the solution found in the SentEvel repo here:
         # https://github.com/facebookresearch/SentEval/blob/6b13ac2060332842f59e84183197402f11451c94/examples/bow.py#L77
-        batch = [sent if sent != [] else ['.'] for sent in batch]
+        batch = [sent if sent != [] else ["."] for sent in batch]
         # Re-tokenize the input text using the pre-trained tokenizer
         batch = [tokenizer.encode(" ".join(tokens)) for tokens in batch]
         batch = _pad_sequences(batch, tokenizer.pad_token_id)
@@ -373,7 +373,7 @@ def sentence_transformers(
         # with HuggingfFace's tokenizer.
         # I am using the solution found in the SentEvel repo here:
         # https://github.com/facebookresearch/SentEval/blob/6b13ac2060332842f59e84183197402f11451c94/examples/bow.py#L77
-        batch = [sent if sent != [] else ['.'] for sent in batch]
+        batch = [sent if sent != [] else ["."] for sent in batch]
         # Sentence Transformers API expects un-tokenized sentences.
         batch = [" ".join(tokens) for tokens in batch]
         embeddings = params.model.encode(batch)
@@ -432,7 +432,7 @@ def allennlp(
         # with HuggingfFace's tokenizer.
         # I am using the solution found in the SentEvel repo here:
         # https://github.com/facebookresearch/SentEval/blob/6b13ac2060332842f59e84183197402f11451c94/examples/bow.py#L77
-        batch = [sent if sent != [] else ['.'] for sent in batch]
+        batch = [sent if sent != [] else ["."] for sent in batch]
         # Re-tokenize the input text using the tokenizer of the dataset reader
         inputs = [{"text": " ".join(tokens)} for tokens in batch]
         outputs = params.predictor.predict_batch_json(inputs)

--- a/scripts/run_senteval.py
+++ b/scripts/run_senteval.py
@@ -280,6 +280,11 @@ def transformers(
 
     @torch.no_grad()
     def batcher(params, batch):
+        # I am not sure why, but some SentEval tasks contain empty batches which triggers an error
+        # with HuggingfFace's tokenizer.
+        # I am using the solution found in the SentEvel repo here:
+        # https://github.com/facebookresearch/SentEval/blob/6b13ac2060332842f59e84183197402f11451c94/examples/bow.py#L77
+        batch = [sent if sent != [] else ['.'] for sent in batch]
         # Re-tokenize the input text using the pre-trained tokenizer
         batch = [tokenizer.encode(" ".join(tokens)) for tokens in batch]
         batch = _pad_sequences(batch, tokenizer.pad_token_id)
@@ -364,6 +369,11 @@ def sentence_transformers(
 
     @torch.no_grad()
     def batcher(params, batch):
+        # I am not sure why, but some SentEval tasks contain empty batches which triggers an error
+        # with HuggingfFace's tokenizer.
+        # I am using the solution found in the SentEvel repo here:
+        # https://github.com/facebookresearch/SentEval/blob/6b13ac2060332842f59e84183197402f11451c94/examples/bow.py#L77
+        batch = [sent if sent != [] else ['.'] for sent in batch]
         # Sentence Transformers API expects un-tokenized sentences.
         batch = [" ".join(tokens) for tokens in batch]
         embeddings = params.model.encode(batch)
@@ -401,6 +411,7 @@ def allennlp(
     prototyping_config: bool = False,
     embeddings_field: str = "embeddings",
     cuda_device: int = -1,
+    opt_level: str = "O0",
     include_package: List[str] = None,
     verbose: bool = False,
 ) -> None:
@@ -417,6 +428,11 @@ def allennlp(
 
     @torch.no_grad()
     def batcher(params, batch):
+        # I am not sure why, but some SentEval tasks contain empty batches which triggers an error
+        # with HuggingfFace's tokenizer.
+        # I am using the solution found in the SentEvel repo here:
+        # https://github.com/facebookresearch/SentEval/blob/6b13ac2060332842f59e84183197402f11451c94/examples/bow.py#L77
+        batch = [sent if sent != [] else ['.'] for sent in batch]
         # Re-tokenize the input text using the tokenizer of the dataset reader
         inputs = [{"text": " ".join(tokens)} for tokens in batch]
         outputs = params.predictor.predict_batch_json(inputs)

--- a/scripts/run_senteval.py
+++ b/scripts/run_senteval.py
@@ -280,8 +280,7 @@ def transformers(
 
     @torch.no_grad()
     def batcher(params, batch):
-        # I am not sure why, but some SentEval tasks contain empty batches which triggers an error
-        # with HuggingfFace's tokenizer.
+        # Some SentEval tasks contain empty batches which triggers an error with HuggingfFace's tokenizer.
         # I am using the solution found in the SentEvel repo here:
         # https://github.com/facebookresearch/SentEval/blob/6b13ac2060332842f59e84183197402f11451c94/examples/bow.py#L77
         batch = [sent if sent != [] else ["."] for sent in batch]
@@ -369,8 +368,7 @@ def sentence_transformers(
 
     @torch.no_grad()
     def batcher(params, batch):
-        # I am not sure why, but some SentEval tasks contain empty batches which triggers an error
-        # with HuggingfFace's tokenizer.
+        # Some SentEval tasks contain empty batches which triggers an error with HuggingfFace's tokenizer.
         # I am using the solution found in the SentEvel repo here:
         # https://github.com/facebookresearch/SentEval/blob/6b13ac2060332842f59e84183197402f11451c94/examples/bow.py#L77
         batch = [sent if sent != [] else ["."] for sent in batch]
@@ -428,8 +426,7 @@ def allennlp(
 
     @torch.no_grad()
     def batcher(params, batch):
-        # I am not sure why, but some SentEval tasks contain empty batches which triggers an error
-        # with HuggingfFace's tokenizer.
+        # Some SentEval tasks contain empty batches which triggers an error with HuggingfFace's tokenizer.
         # I am using the solution found in the SentEvel repo here:
         # https://github.com/facebookresearch/SentEval/blob/6b13ac2060332842f59e84183197402f11451c94/examples/bow.py#L77
         batch = [sent if sent != [] else ["."] for sent in batch]


### PR DESCRIPTION
# Overview

Some SentEval tasks contained empty sentences in certain batches (e.g. CR). Not clear why this is the case, but I have added the fix I found in the SentEval repo, which just defaults to replacing empty sentences with `["."]`. This prevents the script from crashing, which happens on the latest HugginFace Transformers version (`2.7.0`).