### PR TITLE
Improve all configs

### DIFF
--- a/configs/baseline_cls_pooler.jsonnet
+++ b/configs/baseline_cls_pooler.jsonnet
@@ -1,37 +1,32 @@
-// This should be a registered name in the Transformers library (see https://huggingface.co/models) 
 // OR a path on disk to a serialized transformer model. 
-// Note, to avoid issues, please name the serialized model folder in roughly the same format as the
-// Transformers library, e.g.
-// [bert|roberta|gpt2|distillbert|etc]-[base|large|etc]-[uncased|cased|etc]
-local pretrained_transformer_model_name = "distilroberta-base";
-// This will be used to set the max # of tokens in the anchor, positive and negative examples.
+local transformer_model = "distilroberta-base";
+// The hidden size of the model, which can be found in its config as "hidden_size".
+local transformer_dim = 768;
+// This will be used to set the max # of tokens in the positive and negative examples.
 local max_length = 512;
-// This corresponds to PretrainedTransformerEmbedder.transformer_model.config.hidden_size
-local token_embedding_size = 768;
+// Certain transformers use the last special token in the sequence to produce sequence embeddings (e.g XLNet).
+local cls_is_last_token = false;
 
 {
     "dataset_reader": {
         "type": "contrastive",
         "lazy": true,
         "sample_spans": true,
-        // This is (approximately an upper bound on sentence length in English
+        // This is (approximately) an upper bound on sentence length in English
         "min_span_len": 30,
         "tokenizer": {
             "type": "pretrained_transformer",
-            "model_name": pretrained_transformer_model_name,
+            "model_name": transformer_model,
             "max_length": max_length,
         },
         "token_indexers": {
             "tokens": {
                 "type": "pretrained_transformer",
-                "model_name": pretrained_transformer_model_name,
+                "model_name": transformer_model,
             },
         },
-        // If not null, a cache of already-processed data will be stored in this directory.
-        // If a cache file exists at this directory, it will be loaded instead of re-processing the data.
-        "cache_directory": null
     }, 
-    "train_data_path": "",
+    "train_data_path": null,
     "model": {
         "type": "constrastive",
         "text_field_embedder": {
@@ -39,14 +34,15 @@ local token_embedding_size = 768;
             "token_embedders": {
                 "tokens": {
                     "type": "pretrained_transformer_mlm",
-                    "model_name": pretrained_transformer_model_name,
+                    "model_name": transformer_model,
                     "masked_language_modeling": true
                 },
             },
         },
         "seq2vec_encoder": {
             "type": "cls_pooler",
-            "embedding_dim": token_embedding_size,
+            "embedding_dim": transformer_dim,
+            "cls_is_last_token": cls_is_last_token
         },
         "loss": {
             "type": "nt_xent",

--- a/configs/baseline_mean_pooler.jsonnet
+++ b/configs/baseline_mean_pooler.jsonnet
@@ -1,37 +1,31 @@
 // This should be a registered name in the Transformers library (see https://huggingface.co/models) 
 // OR a path on disk to a serialized transformer model. 
-// Note, to avoid issues, please name the serialized model folder in roughly the same format as the
-// Transformers library, e.g.
-// [bert|roberta|gpt2|distillbert|etc]-[base|large|etc]-[uncased|cased|etc]
-local pretrained_transformer_model_name = "distilroberta-base";
-// This will be used to set the max # of tokens in the anchor, positive and negative examples.
+local transformer_model = "distilroberta-base";
+// The hidden size of the model, which can be found in its config as "hidden_size".
+local transformer_dim = 768;
+// This will be used to set the max # of tokens in the positive and negative examples.
 local max_length = 512;
-// This corresponds to PretrainedTransformerEmbedder.transformer_model.config.hidden_size
-local token_embedding_size = 768;
 
 {
     "dataset_reader": {
         "type": "contrastive",
         "lazy": true,
         "sample_spans": true,
-        // This is (approximately an upper bound on sentence length in English
+        // This is (approximately) an upper bound on sentence length in English
         "min_span_len": 30,
         "tokenizer": {
             "type": "pretrained_transformer",
-            "model_name": pretrained_transformer_model_name,
+            "model_name": transformer_model,
             "max_length": max_length,
         },
         "token_indexers": {
             "tokens": {
                 "type": "pretrained_transformer",
-                "model_name": pretrained_transformer_model_name,
+                "model_name": transformer_model,
             },
         },
-        // If not null, a cache of already-processed data will be stored in this directory.
-        // If a cache file exists at this directory, it will be loaded instead of re-processing the data.
-        "cache_directory": null
     }, 
-    "train_data_path": "",
+    "train_data_path": null,
     "model": {
         "type": "constrastive",
         "text_field_embedder": {
@@ -39,14 +33,14 @@ local token_embedding_size = 768;
             "token_embedders": {
                 "tokens": {
                     "type": "pretrained_transformer_mlm",
-                    "model_name": pretrained_transformer_model_name,
+                    "model_name": transformer_model,
                     "masked_language_modeling": true
                 },
             },
         },
         "seq2vec_encoder": {
             "type": "bag_of_embeddings",
-            "embedding_dim": token_embedding_size,
+            "embedding_dim": transformer_dim,
             "averaged": true
         },
         "loss": {

--- a/configs/contrastive.jsonnet
+++ b/configs/contrastive.jsonnet
@@ -1,37 +1,31 @@
 // This should be a registered name in the Transformers library (see https://huggingface.co/models) 
 // OR a path on disk to a serialized transformer model. 
-// Note, to avoid issues, please name the serialized model folder in roughly the same format as the
-// Transformers library, e.g.
-// [bert|roberta|gpt2|distillbert|etc]-[base|large|etc]-[uncased|cased|etc]
-local pretrained_transformer_model_name = "distilroberta-base";
-// This will be used to set the max # of tokens in the anchor, positive and negative examples.
+local transformer_model = "distilroberta-base";
+// The hidden size of the model, which can be found in its config as "hidden_size".
+local transformer_dim = 768;
+// This will be used to set the max # of tokens in the positive and negative examples.
 local max_length = 512;
-// This corresponds to PretrainedTransformerEmbedder.transformer_model.config.hidden_size
-local token_embedding_size = 768;
 
 {
     "dataset_reader": {
         "type": "contrastive",
         "lazy": true,
         "sample_spans": true,
-        // This is (approximately an upper bound on sentence length in English
+        // This is (approximately) an upper bound on sentence length in English
         "min_span_len": 30,
         "tokenizer": {
             "type": "pretrained_transformer",
-            "model_name": pretrained_transformer_model_name,
+            "model_name": transformer_model,
             "max_length": max_length,
         },
         "token_indexers": {
             "tokens": {
                 "type": "pretrained_transformer",
-                "model_name": pretrained_transformer_model_name,
+                "model_name": transformer_model,
             },
         },
-        // If not null, a cache of already-processed data will be stored in this directory.
-        // If a cache file exists at this directory, it will be loaded instead of re-processing the data.
-        "cache_directory": null
     }, 
-    "train_data_path": "",
+    "train_data_path": null,
     "model": {
         "type": "constrastive",
         "text_field_embedder": {
@@ -39,14 +33,14 @@ local token_embedding_size = 768;
             "token_embedders": {
                 "tokens": {
                     "type": "pretrained_transformer_mlm",
-                    "model_name": pretrained_transformer_model_name,
+                    "model_name": transformer_model,
                     "masked_language_modeling": true
                 },
             },
         },
         "seq2vec_encoder": {
             "type": "bag_of_embeddings",
-            "embedding_dim": token_embedding_size,
+            "embedding_dim": transformer_dim,
             "averaged": true
         },
         "loss": {
@@ -78,7 +72,8 @@ local token_embedding_size = 768;
         },
         "num_epochs": 1,
         "checkpointer": {
-            "num_serialized_models_to_keep": 1,
+            // A value of null or -1 will save the weights of the model at the end of every epoch
+            "num_serialized_models_to_keep": -1,
         },
         "cuda_device": 0,
         "grad_norm": 1.0,

--- a/t2t/tests/fixtures/contrastive_text_encoder/common.jsonnet
+++ b/t2t/tests/fixtures/contrastive_text_encoder/common.jsonnet
@@ -1,35 +1,29 @@
 // This should be a registered name in the Transformers library (see https://huggingface.co/models) 
 // OR a path on disk to a serialized transformer model. 
-// Note, to avoid issues, please name the serialized model folder in roughly the same format as the
-// Transformers library, e.g.
-// [bert|roberta|gpt2|distillbert|etc]-[base|large|etc]-[uncased|cased|etc]
-local pretrained_transformer_model_name = "distilroberta-base";
-// This will be used to set the max # of tokens in the anchor, positive and negative examples.
+local transformer_model = "distilroberta-base";
+// The hidden size of the model, which can be found in its config as "hidden_size".
+local transformer_dim = 768;
+// This will be used to set the max # of tokens in the positive and negative examples.
 local max_length = 512;
-// This corresponds to PretrainedTransformerEmbedder.transformer_model.config.hidden_size
-local token_embedding_size = 768;
 
 {
     "dataset_reader": {
         "type": "t2t.data.dataset_readers.contrastive.ContrastiveDatasetReader",
         "lazy": true,
         "sample_spans": true,
-        // This is (approximately an upper bound on sentence length in English
+        // This is (approximately) an upper bound on sentence length in English
         "min_span_len": 30,
         "tokenizer": {
             "type": "pretrained_transformer",
-            "model_name": pretrained_transformer_model_name,
+            "model_name": transformer_model,
             "max_length": max_length,
         },
         "token_indexers": {
             "tokens": {
                 "type": "pretrained_transformer",
-                "model_name": pretrained_transformer_model_name,
+                "model_name": transformer_model,
             },
         },
-        // If not null, a cache of already-processed data will be stored in this directory.
-        // If a cache file exists at this directory, it will be loaded instead of re-processing the data.
-        "cache_directory": null
     }, 
     "train_data_path": "t2t/tests/fixtures/data/wikitext-103/train.txt",
     "validation_data_path": "t2t/tests/fixtures/data/wikitext-103/valid.txt",
@@ -37,7 +31,7 @@ local token_embedding_size = 768;
         "type": "t2t.models.contrastive_text_encoder.ContrastiveTextEncoder",
         "seq2vec_encoder": {
             "type": "bag_of_embeddings",
-            "embedding_dim": token_embedding_size,
+            "embedding_dim": transformer_dim,
             "averaged": true
         },
     },
@@ -65,7 +59,7 @@ local token_embedding_size = 768;
         },
         "num_epochs": 1,
         "checkpointer": {
-            "num_serialized_models_to_keep": 1,
+            "num_serialized_models_to_keep": -1,
         },
         "cuda_device": -1,
         "grad_norm": 1.0,

--- a/t2t/tests/fixtures/contrastive_text_encoder/experiment.jsonnet
+++ b/t2t/tests/fixtures/contrastive_text_encoder/experiment.jsonnet
@@ -1,8 +1,5 @@
 local COMMON = import 'common.jsonnet';
-local pretrained_transformer_model_name = "distilroberta-base";
-
-local COMMON = import 'common.jsonnet';
-local pretrained_transformer_model_name = "distilroberta-base";
+local transformer_model = "distilroberta-base";
 
 {
     "dataset_reader": COMMON['dataset_reader'],
@@ -16,7 +13,7 @@ local pretrained_transformer_model_name = "distilroberta-base";
             "token_embedders": {
                 "tokens": {
                     "type": "t2t.modules.token_embedders.pretrained_transformer_embedder_mlm.PretrainedTransformerEmbedderMLM",
-                    "model_name": pretrained_transformer_model_name,
+                    "model_name": transformer_model,
                     "masked_language_modeling": true
                 },
             },

--- a/t2t/tests/fixtures/contrastive_text_encoder/experiment_contrastive_only.jsonnet
+++ b/t2t/tests/fixtures/contrastive_text_encoder/experiment_contrastive_only.jsonnet
@@ -1,5 +1,5 @@
 local COMMON = import 'common.jsonnet';
-local pretrained_transformer_model_name = "distilroberta-base";
+local transformer_model = "distilroberta-base";
 
 {
     "dataset_reader": COMMON['dataset_reader'],
@@ -13,7 +13,7 @@ local pretrained_transformer_model_name = "distilroberta-base";
             "token_embedders": {
                 "tokens": {
                     "type": "t2t.modules.token_embedders.pretrained_transformer_embedder_mlm.PretrainedTransformerEmbedderMLM",
-                    "model_name": pretrained_transformer_model_name,
+                    "model_name": transformer_model,
                     "masked_language_modeling": false
                 },
             },

--- a/t2t/tests/fixtures/contrastive_text_encoder/experiment_mlm_only.jsonnet
+++ b/t2t/tests/fixtures/contrastive_text_encoder/experiment_mlm_only.jsonnet
@@ -1,5 +1,5 @@
 local COMMON = import 'common.jsonnet';
-local pretrained_transformer_model_name = "distilroberta-base";
+local transformer_model = "distilroberta-base";
 
 {
     "dataset_reader": COMMON['dataset_reader'],
@@ -13,7 +13,7 @@ local pretrained_transformer_model_name = "distilroberta-base";
             "token_embedders": {
                 "tokens": {
                     "type": "t2t.modules.token_embedders.pretrained_transformer_embedder_mlm.PretrainedTransformerEmbedderMLM",
-                    "model_name": pretrained_transformer_model_name,
+                    "model_name": transformer_model,
                     "masked_language_modeling": true
                 },
             },


### PR DESCRIPTION
# Overview

This PR makes several changes to improve the configs

- Rename certain local variables to match the names in similar AllenNLP configs
- Make the default value for `train_data_path` `null`, which will throw a clearer error when a user forgets to specify it.
- Make the default value for `"checkpointer.num_serialized_models_to_keep"` `-1`, which will save a checkpoint at the end of each epoch.
- Remove the `"cache_directory"` argument. This never made sense, as our data is generated stochastically.
- Add `cls_is_last_token` variable to `baseline_cls_pooler.jsonnet`. This generally makes it clearer to a user that they need to specify this (its default is `False`, which will be correct for many pre-trained transformers).