### PR TITLE
Add script to download wikitext 103

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ If you want to train with [mixed-precision](https://devblogs.nvidia.com/mixed-pr
 
 Datasets should be text files where each line contains a raw text sequence. You can specify different partitions in the [configs](configs) under `"train_data_path"`, `"validation_data_path"` and `"test_data_path"`.
 
+We provide scripts to download some popular datasets and prepare them for training with our model. For example, to download [WikiText-103](https://www.salesforce.com/products/einstein/ai-research/the-wikitext-dependency-language-modeling-dataset/) (with minimal preprocessing), you can call
+
+```bash
+python scripts/preprocess_wikitext_103.py path/to/output/wikitext-103/train.txt
+```
+
 ### Training
 
 To train the model, run the following command

--- a/scripts/preprocess_wikitext_103.py
+++ b/scripts/preprocess_wikitext_103.py
@@ -1,0 +1,97 @@
+import io
+import re
+import zipfile
+from pathlib import Path
+from typing import List, Optional
+
+import requests
+import typer
+from transformers import AutoTokenizer
+
+WIKITEXT_103_URL = "https://s3.amazonaws.com/research.metamind.io/wikitext/wikitext-103-raw-v1.zip"
+
+# Emoji's used in typer.secho calls
+# See: https://github.com/carpedm20/emoji/blob/master/emoji/unicode_codes.py"
+SAVING = "\U0001F4BE"
+
+
+def _sanitize(text: str) -> str:
+    """Cleans text by dropping non-ASCII characters and removing whitespace, newlines and tabs.
+    """
+    # Convert to ASCII, dropping anything that can't be converted
+    text = text.encode("ascii", "ignore").decode("utf-8")
+    # Remove whitespace, newlines and tabs
+    text = " ".join(text.strip().split())
+    return text
+
+
+def _write_output_to_disk(text: List[str], output_filepath: str) -> None:
+    """Writes a list of documents, `text`, to the file `output_filepath`, one document per line.
+    """
+    # Create the directory path if it doesn't exist
+    output_filepath = Path(output_filepath)
+    output_filepath.parents[0].mkdir(parents=True, exist_ok=True)
+    with open(output_filepath, "w") as f:
+        f.write("\n".join(text))
+    typer.secho(
+        f"{SAVING} Preprocessed WikiText-103 saved to: {output_filepath}",
+        fg=typer.colors.WHITE,
+        bold=True,
+    )
+
+
+def main(
+    output_filepath: str,
+    min_length: Optional[int] = None,
+    pretrained_model_name_or_path: Optional[str] = None,
+) -> None:
+    """Downloads and lightly pre-processes WikiText-103. If `min_lengthgth` is not None, only documents with at
+    least this many tokens are retained. If `pretrained_model_name_or_path` is not None, the tokenizer will be
+    loaded as `AutoTokenizer.from_pretrained(pretrained_model_name_or_path)` using the HuggingfFace Transformers
+    library. Otherwise `.split()` is used. This argument has no effect if `min_lengthgth is None`.
+    """
+    # Setup the pre-trained tokenizer, if specified
+    if pretrained_model_name_or_path is not None:
+        tokenizer = AutoTokenizer.from_pretrained(pretrained_model_name_or_path)
+    else:
+        tokenizer = None
+
+    # Download WikiText-103
+    r = requests.get(WIKITEXT_103_URL, stream=True)
+    z = zipfile.ZipFile(io.BytesIO(r.content))
+    partition_filenames = z.namelist()[1:]
+
+    preprocessed_text = []
+    for filename in partition_filenames:
+        text = z.open(filename).read().decode("utf-8")
+
+        # Strip out subtitles and split the text into documents
+        no_subtitles = re.sub(r"(=\s){2,5}.*(=\s){2,5}", "", text)
+        documents = re.split(r"=\s.*\s=", no_subtitles)
+
+        with typer.progressbar(
+            documents, label=typer.style(f"Processing {filename}", bold=True)
+        ) as progress:
+            for doc in progress:
+                doc = _sanitize(doc)
+
+                if not doc:
+                    continue
+
+                # Retain the document if min_length is None, or min_length is not None and this document contains
+                # greater than or equal to min_length tokens.
+                if min_length is not None:
+                    if tokenizer is not None:
+                        tokens = tokenizer.tokenize(doc)
+                    else:
+                        tokens = doc.split()
+                    if len(tokens) >= min_length:
+                        preprocessed_text.append(doc)
+                else:
+                    preprocessed_text.append(doc)
+
+    _write_output_to_disk(preprocessed_text, output_filepath)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/scripts/run_senteval.py
+++ b/scripts/run_senteval.py
@@ -440,13 +440,13 @@ def allennlp(
         return embeddings
 
     # This allows us to import custom dataset readers and models that may exist in the AllenNLP archive.
-    # See: https://github.com/allenai/allennlp/blob/e19605aae05eff60b0f41dc521b9787867fa58dd/allennlp/commands/train.py#L404
+    # See: https://tinyurl.com/whkmoqh
     include_package = include_package or []
     for package_name in include_package:
         common_util.import_module_and_submodules(package_name)
 
     # Load the archived Model
-    archive = load_archive(path_to_allennlp_archive, cuda_device=cuda_device)
+    archive = load_archive(path_to_allennlp_archive, cuda_device=cuda_device, opt_level=opt_level)
     predictor = Predictor.from_archive(archive, predictor_name)
     typer.secho(
         f"{SUCCESS}  Model from AllenNLP archive loaded successfully.",


### PR DESCRIPTION
# Overview

Adds a script that downloads (and minimally preprocesses WikiText-103). I did this to 1) Make it easier to get started with our model 2) Make our results more reproducible.

In the future, I think I may add a whole Typer CLI with multiple subcommands for downloading popular text dumps. For now, this is good enough.

## Other changes

- :books: Add instructions to readme on how to use the new preprocess script.
- :bug: Add missing `opt_level` arg in `run_senteval.py`.