### PR TITLE
Add encoder class

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ allennlp train configs/contrastive.jsonnet \
 
 #### As a library
 
-To use the model "as a library," import `Encoder` and pass it some text (it accepts both strings and lists of strings)
+To use the model as a library, import `Encoder` and pass it some text (it accepts both strings and lists of strings)
 
 ```python
 from t2t import Encoder
@@ -99,7 +99,7 @@ these embeddings can then be used, for example, to compute the semantic similari
 ```python
 from scipy.spatial.distance import cosine
 
-semantic_sim = cosine(embeddings[0], embeddings[1])
+semantic_sim = 1 - cosine(embeddings[0], embeddings[1])
 ```
 
 > In the future, we will host pre-trained weights online, so that a model name can be passed to `Encoder` and the model will be automatically downloaded. 
@@ -141,7 +141,7 @@ cd SentEval/data/downstream/
 cd ../../../
 ```
 
-> See the SentEval repository for full details.
+> See the [SentEval](https://github.com/facebookresearch/SentEval) repository for full details.
 
 Then you can run our [script](scripts/run_senteval.py) to evaluate a trained model against SentEval
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ To use the model "as a library," import `Encoder` and pass it some text (it acce
 from t2t import Encoder
 
 encoder = Encoder("path/to/serialized/model")
-embeddings = encode([
+embeddings = encoder([
     "A smiling costumed woman is holding an umbrella.",
     "A happy woman in a fairy costume holds an umbrella."
 ])

--- a/README.md
+++ b/README.md
@@ -77,7 +77,36 @@ allennlp train configs/contrastive.jsonnet \
 
 ### Embedding
 
-To embed text with a trained model, run the following command
+1. As a library (e.g. import and initialize an object which can be used to embed sentences/paragraphs).
+2. Bulk embed all text in a given text file with a simple command-line interface.
+
+#### As a library
+
+To use the model "as a library," import `Encoder` and pass it some text (it accepts both strings and lists of strings)
+
+```python
+from t2t import Encoder
+
+encoder = Encoder("path/to/serialized/model")
+embeddings = encode([
+    "A smiling costumed woman is holding an umbrella.",
+    "A happy woman in a fairy costume holds an umbrella."
+])
+```
+
+these embeddings can then be used, for example, to compute the semantic similarity between some number of sentences or paragraphs
+
+```python
+from scipy.spatial.distance import cosine
+
+semantic_sim = cosine(embeddings[0], embeddings[1])
+```
+
+> In the future, we will host pre-trained weights online, so that a model name can be passed to `Encoder` and the model will be automatically downloaded. 
+
+#### Bulk embed a file
+
+To embed all text in a given file with a trained model, run the following command
 
 ```bash
 allennlp predict output path/to/input.txt \

--- a/t2t/__init__.py
+++ b/t2t/__init__.py
@@ -1,0 +1,1 @@
+from t2t.encoder import Encoder

--- a/t2t/encoder.py
+++ b/t2t/encoder.py
@@ -1,8 +1,10 @@
+from typing import List, Union
+
+import numpy as np
+
+from allennlp.common import util as common_util
 from allennlp.models.archival import load_archive
 from allennlp.predictors import Predictor
-from typing import Union, List
-from allennlp.common import util as common_util
-import numpy as np
 
 
 class Encoder:
@@ -12,12 +14,13 @@ class Encoder:
         common_util.import_module_and_submodules("t2t")
         archive = load_archive(path_to_allennlp_archive, **kwargs)
         self._predictor = Predictor.from_archive(archive, predictor_name="contrastive")
+        self._output_dict_field = "embeddings"
 
-    def __call__(self, inputs: Union[str, List[str]]):
+    def __call__(self, inputs: Union[str, List[str]]) -> np.ndarray:
         if isinstance(inputs, str):
             inputs = [inputs]
         json_formatted_inputs = [{"text": input_} for input_ in inputs]
         outputs = self._predictor.predict_batch_json(json_formatted_inputs)
-        embeddings = [output["embeddings"] for output in outputs]
+        embeddings = [output[self._output_dict_field] for output in outputs]
         embeddings = np.vstack(embeddings)
         return embeddings

--- a/t2t/encoder.py
+++ b/t2t/encoder.py
@@ -1,0 +1,23 @@
+from allennlp.models.archival import load_archive
+from allennlp.predictors import Predictor
+from typing import Union, List
+from allennlp.common import util as common_util
+import numpy as np
+
+
+class Encoder:
+    """A simple interface to the model for the purposes of embedding sentences/paragraphs."""
+
+    def __init__(self, path_to_allennlp_archive: str, **kwargs) -> None:
+        common_util.import_module_and_submodules("t2t")
+        archive = load_archive(path_to_allennlp_archive, **kwargs)
+        self._predictor = Predictor.from_archive(archive, predictor_name="contrastive")
+
+    def __call__(self, inputs: Union[str, List[str]]):
+        if isinstance(inputs, str):
+            inputs = [inputs]
+        json_formatted_inputs = [{"text": input_} for input_ in inputs]
+        outputs = self._predictor.predict_batch_json(json_formatted_inputs)
+        embeddings = [output["embeddings"] for output in outputs]
+        embeddings = np.vstack(embeddings)
+        return embeddings

--- a/t2t/models/contrastive_text_encoder.py
+++ b/t2t/models/contrastive_text_encoder.py
@@ -151,7 +151,6 @@ class ContrastiveTextEncoder(Model):
         # Don't hold on to embeddings or projections during training.
         if output_dict is not None and not self.training:
             output_dict["embeddings"] = embedded_text.clone().detach()
-            # output_dict["embeddings"] /= torch.norm(output_dict["embeddings"])
 
         # Representations produced by a non-linear projection can be used for training with a contrastive loss.
         # Previous works in computer vision have found this projection head to improve the quality of the learned
@@ -162,6 +161,5 @@ class ContrastiveTextEncoder(Model):
             embedded_text = self._feedforward(embedded_text)
             if output_dict is not None and not self.training:
                 output_dict["projections"] = embedded_text.clone().detach()
-                # output_dict["projections"] /= torch.norm(output_dict["projections"])
 
         return masked_lm_loss, embedded_text

--- a/t2t/predictors/__init__.py
+++ b/t2t/predictors/__init__.py
@@ -1,2 +1,1 @@
-from t2t.predictors.contrastive_predictor import no_sample
 from t2t.predictors.contrastive_predictor import ContrastivePredictor


### PR DESCRIPTION
# Overview

Adds a simple interface to embed text with a trained model

```python
from t2t import Encoder

encoder = Encoder("path/to/serialized/model")
embeddings = encode([
    "A smiling costumed woman is holding an umbrella.",
    "A happy woman in a fairy costume holds an umbrella."
])
```

this can be used, among other things, to determine the semantic similarity of two pieces of text

```python
from scipy.spatial.distance import cosine

semantic_sim = cosine(embeddings[0], embeddings[1])
```

## Other changes

- :bug: Last PR (#72) introduced bugs with incorrect imports in some `__init__.py` files.