### PR TITLE
Add weights file arg to sent eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ To use the model "as a library," import `Encoder` and pass it some text (it acce
 from t2t import Encoder
 
 encoder = Encoder("path/to/serialized/model")
-embeddings = encode([
+embeddings = encoder([
     "A smiling costumed woman is holding an umbrella.",
     "A happy woman in a fairy costume holds an umbrella."
 ])

--- a/README.md
+++ b/README.md
@@ -77,7 +77,36 @@ allennlp train configs/contrastive.jsonnet \
 
 ### Embedding
 
-To embed text with a trained model, run the following command
+1. As a library (e.g. import and initialize an object which can be used to embed sentences/paragraphs).
+2. Bulk embed all text in a given text file with a simple command-line interface.
+
+#### As a library
+
+To use the model "as a library," import `Encoder` and pass it some text (it accepts both strings and lists of strings)
+
+```python
+from t2t import Encoder
+
+encoder = Encoder("path/to/serialized/model")
+embeddings = encode([
+    "A smiling costumed woman is holding an umbrella.",
+    "A happy woman in a fairy costume holds an umbrella."
+])
+```
+
+these embeddings can then be used, for example, to compute the semantic similarity between some number of sentences or paragraphs
+
+```python
+from scipy.spatial.distance import cosine
+
+semantic_sim = cosine(embeddings[0], embeddings[1])
+```
+
+> In the future, we will host pre-trained weights online, so that a model name can be passed to `Encoder` and the model will be automatically downloaded. 
+
+#### Bulk embed a file
+
+To embed all text in a given file with a trained model, run the following command
 
 ```bash
 allennlp predict output path/to/input.txt \

--- a/README.md
+++ b/README.md
@@ -146,9 +146,10 @@ cd ../../../
 Then you can run our [script](scripts/run_senteval.py) to evaluate a trained model against SentEval
 
 ```bash
-python scripts/run_senteval.py allennlp SentEval output "contrastive" \
+python scripts/run_senteval.py allennlp SentEval output 
  --output-filepath output/senteval_results.json \
  --cuda-device 0  \
+ --predictor-name "contrastive" \
  --include-package t2t
 ```
 

--- a/scripts/run_senteval.py
+++ b/scripts/run_senteval.py
@@ -147,7 +147,7 @@ def _setup_mixed_precision_with_amp(model: torch.nn.Module, opt_level: str = Non
 
         model = amp.initialize(model, opt_level=opt_level)
         typer.secho(
-            f'{FAST} Using mixed-precision with "opt_level={opt_level}".',
+            f'{FAST}  Using mixed-precision with "opt_level={opt_level}".',
             fg=typer.colors.WHITE,
             bold=True,
         )
@@ -174,8 +174,8 @@ def _setup_senteval(
     if prototyping_config:
         typer.secho(
             (
-                f"{WARNING} Using prototyping config. Pass --no-prototyping-config to get results comparable to"
-                "  the literature."
+                f"{WARNING}  Using prototyping config. Pass --no-prototyping-config to get results comparable to"
+                " the literature."
             ),
             fg=typer.colors.YELLOW,
             bold=True,
@@ -222,7 +222,7 @@ def _run_senteval(
 
     aggregate_scores = _compute_aggregate_scores(results)
     typer.secho(
-        f'{SCORE} Aggregate dev score: {aggregate_scores["all"]["dev"]:.2f}%',
+        f'{SCORE}  Aggregate dev score: {aggregate_scores["all"]["dev"]:.2f}%',
         fg=typer.colors.WHITE,
         bold=True,
     )
@@ -242,7 +242,7 @@ def _run_senteval(
         )
     else:
         typer.secho(
-            f"{WARNING} --output_filepath was not provided, printing results to console instead.",
+            f"{WARNING}  --output_filepath was not provided, printing results to console instead.",
             fg=typer.colors.YELLOW,
             bold=True,
         )
@@ -262,10 +262,10 @@ def transformers(
     path_to_senteval: str,
     pretrained_model_name_or_path: str,
     output_filepath: str = None,
-    prototyping_config: bool = False,
     mean_pool: bool = False,
     cuda_device: int = -1,
     opt_level: str = None,
+    prototyping_config: bool = False,
     verbose: bool = False,
 ) -> None:
     """Evaluates a pre-trained model from the Transformers library against the SentEval benchmark.
@@ -328,7 +328,7 @@ def transformers(
     model = AutoModel.from_pretrained(pretrained_model_name_or_path).to(device)
     model.eval()
     typer.secho(
-        f'{SUCCESS} Model "{pretrained_model_name_or_path}" from Transformers loaded successfully.',
+        f'{SUCCESS}  Model "{pretrained_model_name_or_path}" from Transformers loaded successfully.',
         fg=typer.colors.GREEN,
         bold=True,
     )
@@ -351,9 +351,9 @@ def sentence_transformers(
     path_to_senteval: str,
     pretrained_model_name_or_path: str,
     output_filepath: str = None,
-    prototyping_config: bool = False,
     cuda_device: int = -1,
     opt_level: str = None,
+    prototyping_config: bool = False,
     verbose: bool = False,
 ) -> None:
     """Evaluates a pre-trained model from the Sentence Transformers library against the SentEval benchmark.
@@ -385,7 +385,7 @@ def sentence_transformers(
     model = SentenceTransformer(pretrained_model_name_or_path, device=device)
     model.eval()
     typer.secho(
-        f'{SUCCESS} Model "{pretrained_model_name_or_path}" from Sentence Transformers loaded successfully.',
+        f'{SUCCESS}  Model "{pretrained_model_name_or_path}" from Sentence Transformers loaded successfully.',
         fg=typer.colors.GREEN,
         bold=True,
     )
@@ -404,13 +404,14 @@ def sentence_transformers(
 def allennlp(
     path_to_senteval: str,
     path_to_allennlp_archive: str,
-    predictor_name: str,
     output_filepath: str = None,
-    prototyping_config: bool = False,
-    embeddings_field: str = "embeddings",
+    weights_file: str = None,
     cuda_device: int = -1,
     opt_level: str = "O0",
+    output_dict_field: str = "embeddings",
+    predictor_name: str = None,
     include_package: List[str] = None,
+    prototyping_config: bool = False,
     verbose: bool = False,
 ) -> None:
     """Evaluates a trained AllenNLP model against the SentEval benchmark.
@@ -434,7 +435,7 @@ def allennlp(
         inputs = [{"text": " ".join(tokens)} for tokens in batch]
         outputs = params.predictor.predict_batch_json(inputs)
         # AllenNLP models return a dictionary, so we need to access the embeddings with the given key.
-        embeddings = [output[embeddings_field] for output in outputs]
+        embeddings = [output[output_dict_field] for output in outputs]
 
         embeddings = np.vstack(embeddings)
         return embeddings
@@ -446,10 +447,15 @@ def allennlp(
         common_util.import_module_and_submodules(package_name)
 
     # Load the archived Model
-    archive = load_archive(path_to_allennlp_archive, cuda_device=cuda_device, opt_level=opt_level)
+    archive = load_archive(
+        path_to_allennlp_archive,
+        cuda_device=cuda_device,
+        opt_level=opt_level,
+        weights_file=weights_file,
+    )
     predictor = Predictor.from_archive(archive, predictor_name)
     typer.secho(
-        f"{SUCCESS}  Model from AllenNLP archive loaded successfully.",
+        f'{SUCCESS}  Model from AllenNLP archive "{path_to_allennlp_archive}" loaded successfully.',
         fg=typer.colors.GREEN,
         bold=True,
     )

--- a/t2t/__init__.py
+++ b/t2t/__init__.py
@@ -1,0 +1,1 @@
+from t2t.encoder import Encoder

--- a/t2t/encoder.py
+++ b/t2t/encoder.py
@@ -1,0 +1,23 @@
+from allennlp.models.archival import load_archive
+from allennlp.predictors import Predictor
+from typing import Union, List
+from allennlp.common import util as common_util
+import numpy as np
+
+
+class Encoder:
+    """A simple interface to the model for the purposes of embedding sentences/paragraphs."""
+
+    def __init__(self, path_to_allennlp_archive: str, **kwargs) -> None:
+        common_util.import_module_and_submodules("t2t")
+        archive = load_archive(path_to_allennlp_archive, **kwargs)
+        self._predictor = Predictor.from_archive(archive, predictor_name="contrastive")
+
+    def __call__(self, inputs: Union[str, List[str]]):
+        if isinstance(inputs, str):
+            inputs = [inputs]
+        json_formatted_inputs = [{"text": input_} for input_ in inputs]
+        outputs = self._predictor.predict_batch_json(json_formatted_inputs)
+        embeddings = [output["embeddings"] for output in outputs]
+        embeddings = np.vstack(embeddings)
+        return embeddings

--- a/t2t/predictors/__init__.py
+++ b/t2t/predictors/__init__.py
@@ -1,2 +1,1 @@
-from t2t.predictors.contrastive_predictor import no_sample
 from t2t.predictors.contrastive_predictor import ContrastivePredictor


### PR DESCRIPTION
# Overview

Small tweak to `run_senteval.py` that allows you to provide a `weights-file` argument when evaluating AllenNLP models. This argument works the same way it does with the AllenNLP [`predict`](https://docs.allennlp.org/master/api/commands/predict/) command. If not supplied, defaults to `path_to_allennlp_archive/best.th`.

## Other changes

- :books: Update readme to reflect slight change in order of the args to `run_senteval.py`.