### PR TITLE
Add randomly initialized vectors sanity check

### DIFF
--- a/scripts/run_senteval.py
+++ b/scripts/run_senteval.py
@@ -251,6 +251,33 @@ def _run_senteval(
 
 
 @app.command()
+def random(
+    path_to_senteval: str,
+    embedding_dim: int = 512,
+    output_filepath: str = None,
+    prototyping_config: bool = False,
+    verbose: bool = False,
+) -> None:
+    """Sanity check that evaluates randomly initialized vectors against the SentEval benchmark.
+    """
+
+    # SentEval prepare and batcher
+    def prepare(params, samples):
+        return
+
+    @torch.no_grad()
+    def batcher(params, batch):
+        embeddings = torch.randn(len(batch), embedding_dim)
+        return embeddings.numpy()
+
+    # Performs a few setup steps and returns the SentEval params
+    params_senteval = _setup_senteval(path_to_senteval, prototyping_config, verbose)
+    _run_senteval(params_senteval, path_to_senteval, batcher, prepare, output_filepath)
+
+    return
+
+
+@app.command()
 def bow() -> None:
     """Evaluates pre-trained word vectors against the SentEval benchmark.
     """


### PR DESCRIPTION
# Overview

This PR adds another subcommand to `run_senteval.py` that serves as a sanity check. It simply returns randomly initialized embeddings for each input in a batch. As expected, performance on SentEval is maximally bad (e.g. 50% for binary tasks, near 0% for regression tasks).

Usage is as follows:

```bash
python scripts/run_senteval.py random --embedding-dim 512
```

I did this mainly because of all the weird results we are getting. Trying to rule out everything I can (this goes some of the way in ruling out the possibility that our SentEval runner is broken).