### PR TITLE
Turn "on" SNLI in run_senteval

### DIFF
--- a/scripts/run_senteval.py
+++ b/scripts/run_senteval.py
@@ -28,7 +28,7 @@ app = typer.Typer()
 # Set up logger
 logger = logging.getLogger(__name__)
 
-# URL to the TF Hub download for Google USE large model
+# URL to the TF Hub download for Google USE base model
 GOOGLE_USE_TF_HUB = "https://tfhub.dev/google/universal-sentence-encoder/4"
 
 DOWNSTREAM_TASKS = [
@@ -40,7 +40,7 @@ DOWNSTREAM_TASKS = [
     "SST5",
     "TREC",
     "MRPC",
-    # "SNLI",
+    "SNLI",
     "SICKEntailment",
     "SICKRelatedness",
     "STSBenchmark",


### PR DESCRIPTION
# Overview

Just adds "SNLI" to the list of tasks in `run_senteval.py`. This brings us to 26/27 total tasks. The "ImageCaptionRetrival" task is still broken (?).

@OsvaldN this will change your scores slightly. I noticed that mine increased a fraction of a percent. Just note, you need to manually edit `SentEval/senteval/snli.py` (as per https://github.com/facebookresearch/SentEval/pull/52), specifically, make this single-line change: https://github.com/facebookresearch/SentEval/pull/52/commits/0291f274d7674fb6a1ea8fb7a58426ab28adeb0f

## Other changes

- Make the default Google USE model the base one.