### PR TITLE
Add script to preprocess openwebtext

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ If you want to train with [mixed-precision](https://devblogs.nvidia.com/mixed-pr
 
 Datasets should be text files where each line contains a raw text sequence. You can specify different partitions in the [configs](configs) under `"train_data_path"`, `"validation_data_path"` and `"test_data_path"`.
 
-We provide scripts to download some popular datasets and prepare them for training with our model. For example, to download [WikiText-103](https://www.salesforce.com/products/einstein/ai-research/the-wikitext-dependency-language-modeling-dataset/) (with minimal preprocessing), you can call
+We provide scripts to download some popular datasets and prepare them for training with our model. For example, to download [WikiText-103](https://www.salesforce.com/products/einstein/ai-research/the-wikitext-dependency-language-modeling-dataset/) (and match our minimal preprocessing), you can call
 
 ```bash
-python scripts/preprocess_wikitext_103.py path/to/output/wikitext-103/train.txt
+python scripts/preprocess_wikitext_103.py path/to/output/wikitext-103/train.txt --min-length 1024
 ```
 
 ### Training

--- a/scripts/preprocess_openwebtext.py
+++ b/scripts/preprocess_openwebtext.py
@@ -1,0 +1,105 @@
+import shutil
+import tarfile
+from pathlib import Path
+from typing import List, Optional
+
+import typer
+from transformers import AutoTokenizer
+
+# Emoji's used in typer.secho calls
+# See: https://github.com/carpedm20/emoji/blob/master/emoji/unicode_codes.py"
+WARNING = "\U000026A0"
+SAVING = "\U0001F4BE"
+
+
+def _write_output_to_disk(text: List[str], output_filepath: str) -> None:
+    """Writes a list of documents, `text`, to the file `output_filepath`, one document per line.
+    """
+    # Create the directory path if it doesn't exist
+    output_filepath = Path(output_filepath)
+    output_filepath.parents[0].mkdir(parents=True, exist_ok=True)
+
+    with open(output_filepath, "w") as f:
+        f.write("\n".join(text))
+    typer.secho(
+        f"{SAVING} Preprocessed OpenWebText saved to: {output_filepath}",
+        fg=typer.colors.WHITE,
+        bold=True,
+    )
+
+
+def main(
+    openwebtext_path: str,
+    output_filepath: str,
+    min_length: Optional[int] = None,
+    max_documents: Optional[int] = None,
+    pretrained_model_name_or_path: Optional[str] = None,
+) -> None:
+    """Lightly pre-processes an OpenWebText dump obtained from https://skylion007.github.io/OpenWebTextCorpus/.
+    If `min_length` is not None, only documents whose shortest paragraph have at least this many tokens are
+    retained. If `pretrained_model_name_or_path` is not None, the tokenizer will be loaded as
+    `AutoTokenizer.from_pretrained(pretrained_model_name_or_path)` using the HuggingFace's Transformers library.
+    Otherwise `.split()` is used. This argument has no effect if `min_length is None`.
+    """
+    openwebtext_path = Path(openwebtext_path)
+
+    # Setup the pre-trained tokenizer, if specified
+    if min_length is not None:
+        if pretrained_model_name_or_path is not None:
+            tokenizer = AutoTokenizer.from_pretrained(pretrained_model_name_or_path).tokenize
+        else:
+            tokenizer = lambda x: x.split()  # noqa
+    else:
+        tokenizer = None
+
+    early_exit = False
+    documents = []
+    skipped_files = 0
+    with typer.progressbar(length=max_documents, label="Processing") as progress:
+        for i, tar_filepath in enumerate(openwebtext_path.iterdir()):
+            untared_filepath = Path(tar_filepath.stem)
+            try:
+                with tarfile.open(tar_filepath) as f:
+                    f.extractall(untared_filepath)
+            except (tarfile.ReadError, IsADirectoryError):
+                skipped_files += 1
+                continue
+
+            for text_filepath in untared_filepath.iterdir():
+                # Drop empty lines
+                paragraphs = [
+                    paragraph for paragraph in text_filepath.read_text().split("\n\n") if paragraph
+                ]
+
+                # We need at least two paragraphs to define a pair for the contrastive objective
+                if len(paragraphs) < 2:
+                    continue
+
+                # Retain documents if the length of their shortest document is equal to or greater than
+                # the minimum specified length
+                if tokenizer is not None:
+                    paragraphs_len = [len(tokenizer(paragraph)) for paragraph in paragraphs]
+                    if min(paragraphs_len) >= min_length:
+                        documents.append("\t".join(paragraphs))
+                        progress.update(1)
+                else:
+                    documents.append("\t".join(paragraphs))
+                    progress.update(1)
+                if max_documents and len(documents) >= max_documents:
+                    early_exit = True
+                    break
+            shutil.rmtree(untared_filepath)
+            if early_exit:
+                break
+
+    if skipped_files > 0:
+        typer.secho(
+            f"{WARNING} {skipped_files} tar files were skipped because they couldn't be extracted.",
+            fg=typer.colors.YELLOW,
+            bold=True,
+        )
+    _write_output_to_disk(documents, output_filepath)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/scripts/preprocess_openwebtext.py
+++ b/scripts/preprocess_openwebtext.py
@@ -4,12 +4,22 @@ from pathlib import Path
 from typing import List, Optional
 
 import typer
-from transformers import AutoTokenizer
 
 # Emoji's used in typer.secho calls
 # See: https://github.com/carpedm20/emoji/blob/master/emoji/unicode_codes.py"
 WARNING = "\U000026A0"
 SAVING = "\U0001F4BE"
+MINING = "\U000026CF"
+
+
+def _sanitize(text: str) -> str:
+    """Cleans text by dropping non-ASCII characters and removing whitespace, newlines and tabs.
+    """
+    # Convert to ASCII, dropping anything that can't be converted
+    text = text.encode("ascii", "ignore").decode("utf-8")
+    # Remove whitespace, newlines and tabs
+    text = " ".join(text.strip().split())
+    return text
 
 
 def _write_output_to_disk(text: List[str], output_filepath: str) -> None:
@@ -20,7 +30,14 @@ def _write_output_to_disk(text: List[str], output_filepath: str) -> None:
     output_filepath.parents[0].mkdir(parents=True, exist_ok=True)
 
     with open(output_filepath, "w") as f:
-        f.write("\n".join(text))
+        # TODO (John): In the future, it might make sense to both batch and shard:
+        # 1) Batch, meaning write batches of documents to a file as opposed to 1 at a time
+        # 2) Shard, meaning break a file up into shard_size // len(text) files, and return a
+        #    directory instead. Loading a dataset like this is supported in AllenNLP (see:
+        #    https://docs.allennlp.org/master/api/data/dataset_readers/sharded_dataset_reader/)
+        with typer.progressbar(text, label="Writing to disk") as progres:
+            for doc in progres:
+                f.write(doc + "\n")
     typer.secho(
         f"{SAVING} Preprocessed OpenWebText saved to: {output_filepath}",
         fg=typer.colors.WHITE,
@@ -35,17 +52,22 @@ def main(
     max_documents: Optional[int] = None,
     pretrained_model_name_or_path: Optional[str] = None,
 ) -> None:
-    """Lightly pre-processes an OpenWebText dump obtained from https://skylion007.github.io/OpenWebTextCorpus/.
-    If `min_length` is not None, only documents whose shortest paragraph have at least this many tokens are
-    retained. If `pretrained_model_name_or_path` is not None, the tokenizer will be loaded as
-    `AutoTokenizer.from_pretrained(pretrained_model_name_or_path)` using the HuggingFace's Transformers library.
-    Otherwise `.split()` is used. This argument has no effect if `min_length is None`.
+    """Lightly pre-processes an OpenWebText dump obtained from
+    https://skylion007.github.io/OpenWebTextCorpus/. If `min_length` is not None, only documents
+    with at least this many tokens are retained. If `pretrained_model_name_or_path` is not None, the
+    tokenizer will be loaded as `AutoTokenizer.from_pretrained(pretrained_model_name_or_path)`
+    using the HuggingFace Transformers library. Otherwise `str.split()` is used. This argument has
+    no effect if `min_length is None`.
     """
     openwebtext_path = Path(openwebtext_path)
 
     # Setup the pre-trained tokenizer, if specified
     if min_length is not None:
         if pretrained_model_name_or_path is not None:
+            # Import transformers here to prevent ImportError errors if the
+            # user doesn't want to use it.
+            from transformers import AutoTokenizer
+
             tokenizer = AutoTokenizer.from_pretrained(pretrained_model_name_or_path).tokenize
         else:
             tokenizer = lambda x: x.split()  # noqa
@@ -55,8 +77,22 @@ def main(
     early_exit = False
     documents = []
     skipped_files = 0
-    with typer.progressbar(length=max_documents, label="Processing") as progress:
+    typer.secho(
+        (
+            f' {MINING} Scraping {max_documents or "all"} documents'
+            f' {f"with a minimum token length of {min_length}" if min_length else ""}'
+        ),
+        fg=typer.colors.WHITE,
+        bold=True,
+    )
+
+    with typer.progressbar(
+        length=max_documents or len(list(openwebtext_path.iterdir())), label="Preprocessing text"
+    ) as progress:
         for i, tar_filepath in enumerate(openwebtext_path.iterdir()):
+            # HACK (John): I didn't bother trying to debug these as it only happens for a tiny
+            # number (1-2) of tar archives. Instead, I catch the error and report to the user at the
+            # end how many we skipped.
             untared_filepath = Path(tar_filepath.stem)
             try:
                 with tarfile.open(tar_filepath) as f:
@@ -66,29 +102,29 @@ def main(
                 continue
 
             for text_filepath in untared_filepath.iterdir():
-                # Drop empty lines
-                paragraphs = [
-                    paragraph for paragraph in text_filepath.read_text().split("\n\n") if paragraph
-                ]
-
-                # We need at least two paragraphs to define a pair for the contrastive objective
-                if len(paragraphs) < 2:
+                text = text_filepath.read_text()
+                text = _sanitize(text)
+                if not text:
                     continue
 
-                # Retain documents if the length of their shortest document is equal to or greater than
-                # the minimum specified length
+                # Retain documents if the length of their shortest document is
+                # equal to or greater than the minimum specified length
                 if tokenizer is not None:
-                    paragraphs_len = [len(tokenizer(paragraph)) for paragraph in paragraphs]
-                    if min(paragraphs_len) >= min_length:
-                        documents.append("\t".join(paragraphs))
-                        progress.update(1)
-                else:
-                    documents.append("\t".join(paragraphs))
+                    num_tokens = len(tokenizer(text))
+                    if num_tokens < min_length:
+                        continue
+
+                documents.append(text)
+                if max_documents:
                     progress.update(1)
-                if max_documents and len(documents) >= max_documents:
+
+                if max_documents and len(documents) == max_documents:
                     early_exit = True
                     break
+
             shutil.rmtree(untared_filepath)
+            if max_documents is None:
+                progress.update(1)
             if early_exit:
                 break
 

--- a/scripts/preprocess_wikitext_103.py
+++ b/scripts/preprocess_wikitext_103.py
@@ -45,10 +45,10 @@ def main(
     min_length: Optional[int] = None,
     pretrained_model_name_or_path: Optional[str] = None,
 ) -> None:
-    """Downloads and lightly pre-processes WikiText-103. If `min_lengthgth` is not None, only documents with at
+    """Downloads and lightly pre-processes WikiText-103. If `min_length` is not None, only documents with at
     least this many tokens are retained. If `pretrained_model_name_or_path` is not None, the tokenizer will be
     loaded as `AutoTokenizer.from_pretrained(pretrained_model_name_or_path)` using the HuggingfFace Transformers
-    library. Otherwise `.split()` is used. This argument has no effect if `min_lengthgth is None`.
+    library. Otherwise `.split()` is used. This argument has no effect if `min_length is None`.
     """
     # Setup the pre-trained tokenizer, if specified
     if pretrained_model_name_or_path is not None:


### PR DESCRIPTION
# Overview

This PR adds a script to preprocess an OpenWebText dump from [here](https://skylion007.github.io/OpenWebTextCorpus/). Usage looks like:

```bash
python scripts/preprocess_openwebtext.py "path/to/unzipped/openwebtext/dump" "path/to/output/dir/train.txt" --min-length 1024 --max-documents 500000
```

@OsvaldN, in case you want to make a bigger dataset for your experiments. 

---

There are a lot of things I don't like about this setup, but I am trying to quickly try out ideas to improve performance/scaling so I need to cut corners. Detailed explanation of things I don't like listed below (this is just for me to look back on, really)

__All of these have been addressed. Will push the changes in another PR__.

## TODO

- [X]  The `min-length` thing is kind of dumb. Plenty of documents in OpenWebText have "paragraphs" (blocks of text separated by `"\n\n"`) that are very short. This means that the script ignores a huge number of files and takes forever to run. We may need a clever way to combine nearby fragments of text into paragraphs.
- [X] I am tempted to go back to the original procedure of randomly sampling spans, but restrict positives to a "context window". This should solve the problem of "bad positives" but prevent the headaches that come with trying to sample full paragraphs neatly.
- [X] The dataset this script produces contains one document per line, with paragraphs separated by `"\t"`. The current dataset reader does not handle this properly. Locally I just split on `"\t"` and take two random paragraphs from the list that produces. I will think of something cleaner and push it soon.