### PR TITLE
Improved positive sampling procedure

### DIFF
--- a/configs/contrastive_slanted_triangular.jsonnet
+++ b/configs/contrastive_slanted_triangular.jsonnet
@@ -6,6 +6,8 @@ local transformer_dim = 768;
 // This will be used to set the max # of tokens in the positive and negative examples.
 local max_length = 512;
 
+local num_epochs = 1;
+
 {
     "dataset_reader": {
         "type": "contrastive",
@@ -53,7 +55,9 @@ local max_length = 512;
         // I need to modify the dataloader according to:
         // https://pytorch.org/docs/stable/data.html#multi-process-data-loading
         // in order to support multi-processing.
-        "num_workers": 1
+        "num_workers": 1,
+        // This should be the number of instances in the train set / the batch size
+        "batches_per_epoch": null
     },
     "trainer": {
         // If you have installed Apex, you can chose one of its opt_levels here to use mixed precision training.
@@ -69,12 +73,18 @@ local max_length = 512;
                 [["(?=.*transformer_model)(?=.*\\.+)(?!.*(LayerNorm|bias)).*$"], {"weight_decay": 0.1}],
             ],
         },
-        "num_epochs": 1,
+        "num_epochs": num_epochs,
         "checkpointer": {
             // A value of null or -1 will save the weights of the model at the end of every epoch
             "num_serialized_models_to_keep": -1,
         },
         "cuda_device": 0,
         "grad_norm": 1.0,
+        "learning_rate_scheduler": {
+            "type": "slanted_triangular",
+            "num_epochs": num_epochs,
+            // This should be the number of instances in the train set / the batch size
+            "num_steps_per_epoch": null
+        },
     },
 }

--- a/configs/transformer_cls.jsonnet
+++ b/configs/transformer_cls.jsonnet
@@ -12,8 +12,7 @@ local cls_is_last_token = false;
         "type": "contrastive",
         "lazy": true,
         "sample_spans": true,
-        // This is (approximately) an upper bound on sentence length in English
-        "min_span_len": 30,
+        "max_span_len": max_length,
         "tokenizer": {
             "type": "pretrained_transformer",
             "model_name": transformer_model,

--- a/configs/transformer_mean.jsonnet
+++ b/configs/transformer_mean.jsonnet
@@ -11,8 +11,7 @@ local max_length = 512;
         "type": "contrastive",
         "lazy": true,
         "sample_spans": true,
-        // This is (approximately) an upper bound on sentence length in English
-        "min_span_len": 30,
+        "max_span_len": max_length,
         "tokenizer": {
             "type": "pretrained_transformer",
             "model_name": transformer_model,

--- a/t2t/data/dataset_readers/contrastive.py
+++ b/t2t/data/dataset_readers/contrastive.py
@@ -3,9 +3,10 @@ import random
 from contextlib import contextmanager
 from typing import Dict, Iterable, List, Optional
 
-import torch.distributed as dist
+import torch
 from overrides import overrides
 
+from allennlp.common import util
 from allennlp.common.file_utils import cached_path
 from allennlp.data.dataset_readers import DatasetReader
 from allennlp.data.fields import Field, ListField, TextField
@@ -20,11 +21,14 @@ logger = logging.getLogger(__name__)
 @DatasetReader.register("contrastive")
 class ContrastiveDatasetReader(DatasetReader):
     """
-    Read a txt file containing one instance per line, and create a dataset suitable for a `ContrastiveTextEncoder`
-    model.
+    Read a text file containing one instance per line, and create a dataset suitable for a
+    `ContrastiveTextEncoder` model.
 
     The output of `read` is a list of `Instance` s with the field:
         tokens : `ListField[TextField]`
+    if `sample_spans`, else:
+        tokens : `TextField`
+
 
     Registered as a `DatasetReader` with name "contrastive".
 
@@ -38,8 +42,8 @@ class ContrastiveDatasetReader(DatasetReader):
         Tokenizer to use to split the input text into words or other kinds of tokens.
     sample_spans : `bool`, optional (default = True)
         If True, two spans will be sampled from each input, tokenized and indexed.
-    min_span_len : `int`, optional (default = 1)
-        The minimum length of spans which should be sampled. Defaults to 1. Has no effect if
+    max_span_len : `int`, optional
+        The maximum length of spans which should be sampled. Has no effect if
         `sample_spans is False`.
     """
 
@@ -48,17 +52,28 @@ class ContrastiveDatasetReader(DatasetReader):
         token_indexers: Dict[str, TokenIndexer] = None,
         tokenizer: Tokenizer = None,
         sample_spans: bool = False,
-        min_span_len: Optional[int] = None,
+        max_span_len: Optional[int] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self._tokenizer = tokenizer or SpacyTokenizer()
         self._token_indexers = token_indexers or {"tokens": SingleIdTokenIndexer()}
         self._sample_spans = sample_spans
-        self._min_span_len = min_span_len
+        self._max_span_len = max_span_len
 
-        # HACK (John): I need to temporarily disable user warnings because this objects __len__ function returns
-        # 1, which confuses PyTorch.
+        # In the v1.0 AllenNLP pre-release, theres a small catch that dataset readers used in the
+        # distributed setting need to shard instances to separate processes internally such that one
+        # epoch strictly corresponds to one pass over the data. This may get fixed in the v1.0
+        # release. See here: https://github.com/allenai/allennlp/releases.
+        if util.is_distributed():
+            self._rank = torch.distributed.get_rank()
+            self._world_size = torch.distributed.get_world_size()
+        else:
+            self._rank = 0
+            self._world_size = 1
+
+        # HACK (John): I need to temporarily disable user warnings because this objects __len__
+        # function returns 1, which confuses PyTorch.
         import warnings
 
         warnings.filterwarnings("ignore")
@@ -83,18 +98,11 @@ class ContrastiveDatasetReader(DatasetReader):
     def _read(self, file_path: str) -> Iterable[Instance]:
         with open(cached_path(file_path), "r") as data_file:
             logger.info("Reading instances from lines in file at: %s", file_path)
-            # In the v1.0 AllenNLP pre-release, theres a small catch that dataset readers used in the distributed
-            # setting need to shard instances to separate processes internally such that one epoch strictly
-            # corresponds to one pass over the data. This may get fixed in the v1.0 release.
-            # See here: https://github.com/allenai/allennlp/releases.
-            distributed = dist.is_initialized()
-            if distributed:
-                rank = dist.get_rank()
-                world_size = dist.get_world_size()
-            # If we are sampling spans (i.e. we are training) we need to shuffle the data so that we don't yield
-            # instances in the same order every epoch. Our current solution is to read the entire file into memory.
-            # This is a little expensive (roughly 1G per 1 million paragraphs), so a better solution might be
-            # required down the line.
+
+            # If we are sampling spans (i.e. we are training) we need to shuffle the data so that
+            # we don't yield instances in the same order every epoch. Our current solution is to
+            # read the entire file into memory. This is a little expensive (roughly 1G per 1 million
+            # paragraphs), so a better solution might be required down the line.
             if self._sample_spans:
                 data_file = list(enumerate(data_file))
                 random.shuffle(data_file)
@@ -102,11 +110,9 @@ class ContrastiveDatasetReader(DatasetReader):
             else:
                 data_file = enumerate(data_file)
 
-            for idx, text in data_file:
-                if distributed and idx % world_size != rank:
-                    continue
-
-                yield self.text_to_instance(text)
+            for i, text in data_file:
+                if i % self._world_size == self._rank:
+                    yield self.text_to_instance(text)
 
     @overrides
     def text_to_instance(self, text: str) -> Instance:  # type: ignore
@@ -120,14 +126,13 @@ class ContrastiveDatasetReader(DatasetReader):
 
         An `Instance` containing the following fields:
             tokens : `Union[TextField, ListField[TextField]]`
-                If `self._sample_spans`, returns a `ListField` containing `self._sample_spans` number of random,
-                tokenized spans from `text`.
-                Else, returns a `TextField` containing tokenized `text`.
+                If `self._sample_spans`, returns a `ListField` containing two random, tokenized
+                spans from `text`. Else, returns a `TextField` containing tokenized `text`.
         """
         fields: Dict[str, Field] = {}
         if self._sample_spans:
             spans: List[Field] = []
-            for span in sample_spans(text, num_spans=2, min_span_len=self._min_span_len,):
+            for span in sample_spans(text, max_span_len=self._max_span_len):
                 tokens = self._tokenizer.tokenize(span)
                 spans.append(TextField(tokens, self._token_indexers))
             fields["tokens"] = ListField(spans)

--- a/t2t/data/dataset_readers/dataset_utils/contrastive_utils.py
+++ b/t2t/data/dataset_readers/dataset_utils/contrastive_utils.py
@@ -1,41 +1,83 @@
+import random
 from random import randint
-from typing import Callable, Iterable, Optional
+from typing import Callable, Optional, List, Tuple
 
 import numpy as np
 
 
 def sample_spans(
-    text: str, num_spans: int, min_span_len: int, tokenizer: Optional[Callable] = None, **kwargs,
-) -> Iterable[str]:
-    """Returns a generator that yields random spans from `text`.
+    text: str,
+    max_span_len: int,
+    min_span_len: Optional[int] = None,
+    tokenizer: Optional[Callable[[str], List[str]]] = None,
+) -> Tuple[str, str]:
+    """Returns two randomly sampled spans from `text`. The sampling procedure is as follows:
+
+    First, a "context window" of length `max_span_len * 2` is randomly chosen from `text`.
+    Then, with equal probability, we sample either:
+
+        1) Two adjacent spans from the context window of length `max_span_len`
+        2) One "global" span from the context window of length `max_span_len` and one "local"
+           span from the global span of length `min_span_len`.
 
     # Parameters
 
     text : `str`, required
         The string to extract spans from.
-    num_spans : `int`, required
-        The total number of spans to return.
-    min_span_len : `int`, required
-        The minimum length of spans, after whitespace tokenization, to sample.
+    max_span_len : `int`, required
+        The maximum length of spans, after whitespace tokenization, to sample. This number decides
+        the length of the adjacent and global span.
+    min_span_len : `int`, optional
+        The minimum length of spans, after whitespace tokenization, to sample. This number decides
+        the length of the local span. Defaults to `int(0.25 * max_span_len)`.
     tokenizer : `Callable`, optional
         Optional tokenizer to use before sampling spans. If `None`, `text.split()` is used.
     """
+    # If not provided, take the min_span_len to be 1/4 of the max_span_len
+    min_span_len = int(0.25 * max_span_len) if min_span_len is None else min_span_len
+    # The context window is taken to be 2X the max_span_len. The basic idea is that
+    # text that is closer together in a document is more likely to be semantically related,
+    # which increases the chance of sampling "clean" (semantically similar) positives.
+    context_window_len = 2 * max_span_len
 
-    # Whitespace tokenization makes it much more straightforward to do whole word masking but a user can
-    # also provide their own tokenization scheme if they want.
+    # Whitespace tokenization makes it much more straightforward to do whole word masking but a
+    # user can also provide their own tokenization scheme if they want.
     tokens = tokenizer(text) if tokenizer is not None else text.split()
     num_tokens = len(tokens)
-    if min_span_len > num_tokens:
-        tok_method = "tokenizer(text)" if tokenizer else "text.split()"
+    tok_method = "tokenizer(text)" if tokenizer else "text.split()"
+    if min_span_len > max_span_len:
         raise ValueError(
-            f"min_span_len ({min_span_len}) must be less than or equal to len({tok_method}) ({num_tokens})."
+            f"min_span_len ({min_span_len}) must be less than max_span_len ({max_span_len})."
+        )
+    if context_window_len > num_tokens:
+        raise ValueError(
+            (
+                f"context_window_len ({context_window_len}) must be less than or equal to"
+                f" len({tok_method}) ({num_tokens})."
+            )
         )
 
-    for _ in range(num_spans):
-        # 1. Sample span length from a beta distribution, which is skewed towards longer spans.
-        span_length = int(np.random.beta(4, 2) * (num_tokens - min_span_len) + min_span_len)
-        # 2. Sample the start index of the span uniformly
-        start = randint(0, num_tokens - span_length)
-        end = start + span_length
+    # Sample a "context window" from the full text
+    start = randint(0, num_tokens - context_window_len)
+    end = start + context_window_len
+    tokens = tokens[start:end]
 
-        yield " ".join(tokens[start:end])
+    adjacent = random.choice([True, False])
+    # With 50% probability, sample two adjacent views from the context window
+    if adjacent:
+        start = 0
+        end = max_span_len
+        adjacent_view_1 = " ".join(tokens[start:end])
+        adjacent_view_2 = " ".join(tokens[end : end + max_span_len])
+        return adjacent_view_1, adjacent_view_2
+    # With 50% probability, sample "global" and "local" views from the context window
+    else:
+        # Global view
+        start = np.random.randint(0, context_window_len - max_span_len)
+        end = start + max_span_len
+        global_view = " ".join(tokens[start:end])
+        # Local view
+        start = np.random.randint(start, end - min_span_len)
+        end = start + min_span_len
+        local_view = " ".join(tokens[start:end])
+        return global_view, local_view


### PR DESCRIPTION
# Overview

This PR introduces a new and improved procedure for sampling positive examples.

Given a maximum span length, `max_span_len` (we chose 512, the max input size of our transformer) we:

1. Randomly select a _"context window"_ (chosen to be a sequence of `2 * max_span_len` tokens) from each training instance.
2. From the context window, randomly sample two spans:
    - with 50% probability, these spans will be adjacent.
    - with 50% probability, sample a "global" span of length `max_span_len` and _then_ sample a "local" span from the global span of length `0.25 * max_span_len` 

## Generating a dataset

To generate a dataset for this new procedure, first download and extract the OpenWebText dump from [here](https://skylion007.github.io/OpenWebTextCorpus/). Then call

```bash
python scripts/preprocess_openwebtext.py path/to/extracted/openwebtext/dump path/to/openwebtext/train.txt --min-length 1024 --max-documents 500000
```

## Other changes

- Added a new config, `contrastive_slanted_triangular.jsonnet`. This is identical to `contrastive.jsonnet` but adds the slanted triangular learning rate scheduler. I found this improved the models performance when scaling the dataset up.
- The config now requires you to specify a `max_span_len`, not a `min_span_len`.
- Use [hypthosis](https://hypothesis.readthedocs.io/en/latest/index.html) for automaically generating unit tests.
---

A couple of intuitions:

- Restricting sampling from a "context window" increases the likelihood of sampling good (semantically similar) positives.
- Previously, we chose span lengths from a beta distribution. None of my experiments suggest this was better than just taking a constant span length (e.g. 512), so I decided to drop it as I can't justify the extra complexity.
- The adjacent vs. global/local sampling implicitly trains the model against two pretext tasks. This helped in SimCLR and I found that it also helped in our setup.