### PR TITLE
Add recent metric loss and miners

### DIFF
--- a/t2t/losses/__init__.py
+++ b/t2t/losses/__init__.py
@@ -1,5 +1,7 @@
 from t2t.losses.pytorch_metric_learning import (
+    CircleLoss,
     CrossBatchMemory,
+    MultiSimilarityLoss,
     NTXentLoss,
     PyTorchMetricLearningLoss,
 )

--- a/t2t/losses/pytorch_metric_learning.py
+++ b/t2t/losses/pytorch_metric_learning.py
@@ -46,25 +46,27 @@ class PyTorchMetricLearningLoss(Registrable):
         return embeddings, labels
 
 
-@PyTorchMetricLearningLoss.register("nt_xent")
-class NTXentLoss(PyTorchMetricLearningLoss, losses.NTXentLoss):
-    """Wraps the `NTXentLoss` implementation from Pytorch Metric Learning:
-    (https://kevinmusgrave.github.io/pytorch-metric-learning/losses/#ntxentloss).
+@PyTorchMetricLearningLoss.register("circle_loss")
+class CircleLoss(PyTorchMetricLearningLoss, losses.CircleLoss):
+    """Wraps the `CircleLoss` implementation from Pytorch Metric Learning:
+    (https://kevinmusgrave.github.io/pytorch-metric-learning/losses/#circleloss).
 
-    Registered as a `PyTorchMetricLearningLoss` with name "nt_xent".
+    Registered as a `PyTorchMetricLearningLoss` with name "circle_loss".
     """
 
     def __init__(
         self,
-        temperature: float,
-        normalize_embeddings: bool = True,
+        m: float = 0.4,
+        gamma: int = 80,
+        triplets_per_anchor: str = "all",
         num_class_per_param: int = None,
         learnable_param_names: List[str] = None,
     ) -> None:
 
         super().__init__(
-            temperature=temperature,
-            normalize_embeddings=normalize_embeddings,
+            m=m,
+            gamma=gamma,
+            triplets_per_anchor=triplets_per_anchor,
             num_class_per_param=num_class_per_param,
             learnable_param_names=learnable_param_names,
         )
@@ -88,4 +90,56 @@ class CrossBatchMemory(PyTorchMetricLearningLoss, losses.CrossBatchMemory):
 
         super().__init__(
             loss=loss, embedding_size=embedding_size, memory_size=memory_size, miner=miner,
+        )
+
+
+@PyTorchMetricLearningLoss.register("multi_sim_loss")
+class MultiSimilarityLoss(PyTorchMetricLearningLoss, losses.MultiSimilarityLoss):
+    """Wraps the `MultiSimilarityLoss` implementation from Pytorch Metric Learning:
+    (https://kevinmusgrave.github.io/pytorch-metric-learning/losses/#multisimilarityloss).
+
+    Registered as a `PyTorchMetricLearningLoss` with name "multi_sim_loss".
+    """
+
+    def __init__(
+        self,
+        alpha: float,
+        beta: float,
+        base: float = 0.5,
+        normalize_embeddings: bool = True,
+        num_class_per_param: int = None,
+        learnable_param_names: List[str] = None,
+    ) -> None:
+
+        super().__init__(
+            alpha=alpha,
+            beta=beta,
+            base=base,
+            normalize_embeddings=normalize_embeddings,
+            num_class_per_param=num_class_per_param,
+            learnable_param_names=learnable_param_names,
+        )
+
+
+@PyTorchMetricLearningLoss.register("nt_xent")
+class NTXentLoss(PyTorchMetricLearningLoss, losses.NTXentLoss):
+    """Wraps the `NTXentLoss` implementation from Pytorch Metric Learning:
+    (https://kevinmusgrave.github.io/pytorch-metric-learning/losses/#ntxentloss).
+
+    Registered as a `PyTorchMetricLearningLoss` with name "nt_xent".
+    """
+
+    def __init__(
+        self,
+        temperature: float,
+        normalize_embeddings: bool = True,
+        num_class_per_param: int = None,
+        learnable_param_names: List[str] = None,
+    ) -> None:
+
+        super().__init__(
+            temperature=temperature,
+            normalize_embeddings=normalize_embeddings,
+            num_class_per_param=num_class_per_param,
+            learnable_param_names=learnable_param_names,
         )

--- a/t2t/miners/__init__.py
+++ b/t2t/miners/__init__.py
@@ -1,1 +1,5 @@
-from t2t.miners.pytorch_metric_learning import BatchHardMiner, PyTorchMetricLearningMiner
+from t2t.miners.pytorch_metric_learning import (
+    BatchHardMiner,
+    MultiSimilarityMiner,
+    PyTorchMetricLearningMiner,
+)

--- a/t2t/miners/pytorch_metric_learning.py
+++ b/t2t/miners/pytorch_metric_learning.py
@@ -58,3 +58,18 @@ class HDCMiner(PyTorchMetricLearningMiner, miners.HDCMiner):
             squared_distances=squared_distances,
             normalize_embeddings=normalize_embeddings,
         )
+
+
+@PyTorchMetricLearningMiner.register("multi_sim_miner")
+class MultiSimilarityMiner(PyTorchMetricLearningMiner, miners.MultiSimilarityMiner):
+    """Wraps the `MultiSimilarityMiner` implementation from Pytorch Metric Learning:
+    (https://kevinmusgrave.github.io/pytorch-metric-learning/miners/#multisimilarityminer).
+
+    Registered as a `PyTorchMetricLearningMiner` with name "multi_sim_miner".
+    """
+
+    def __init__(self, epsilon: float, normalize_embeddings: bool = True,) -> None:
+
+        super().__init__(
+            epsilon=epsilon, normalize_embeddings=normalize_embeddings,
+        )

--- a/t2t/tests/models/test_contrastive_text_encoder_util.py
+++ b/t2t/tests/models/test_contrastive_text_encoder_util.py
@@ -1,0 +1,27 @@
+from t2t.models.contrastive_text_encoder_util import get_anchor_positive_pairs
+from allennlp.data import TextFieldTensors
+import torch
+
+
+class TestContrastiveTextEncoderUtil:
+    def test_get_anchor_positive_pairs(self):
+        batch_size, max_len = 4, 12  # arbitrary
+
+        # Create some dummy data
+        anchors_expected = torch.randn(batch_size, 1, max_len)
+        positives_expected = torch.randn(batch_size, 1, max_len)
+        token_ids = torch.cat((anchors_expected, positives_expected), dim=1)
+        mask = token_ids.clone()
+        type_ids = token_ids.clone()
+
+        tokens: TextFieldTensors = {
+            "tokens": {"token_ids": token_ids, "mask": mask, "type_ids": type_ids}
+        }
+
+        anchors_actual, positives_actual = get_anchor_positive_pairs(tokens)
+
+        # Check that the function properly splits up the input TextFieldTensors
+        for tensor in anchors_actual["tokens"].values():
+            assert torch.equal(tensor, anchors_expected.squeeze(1))
+        for tensor in positives_actual["tokens"].values():
+            assert torch.equal(tensor, positives_expected.squeeze(1))


### PR DESCRIPTION
# Overview

Adds wrappers for some recently published losses and miners that I found:

#### Losses

- Multi-similarity loss [[Paper](https://arxiv.org/abs/1904.06627)] [[Implementation](https://kevinmusgrave.github.io/pytorch-metric-learning/losses/#multisimilarityloss)]
- CircleLoss loss [[Paper](https://arxiv.org/abs/2002.10857)] [[Implementation](https://kevinmusgrave.github.io/pytorch-metric-learning/losses/#circleloss)]

#### Miners

- Multi-similarity miner [[Paper](https://arxiv.org/abs/1904.06627)] [[Implementation](https://kevinmusgrave.github.io/pytorch-metric-learning/miners/#multisimilarityminer)]

They can be added to the config just like the current loss function. For example, adding the milti-similarity loss and miner looks like:

```python
        "loss": {
            "type": "multi_sim_loss",
            "alpha": 2,
            "beta": 50,
            "base": 1
        },
        "miner": {
            "type": "multi_sim_miner",
            "epsilon": 0.1
        },
```

taking the default hyperparm values from the paper.

Both losses achieve slightly worse results than our current loss with the default hyperparams, but I am curious if they improve performance when using a large number of negatives. 

## Other changes:

- :recycle: Refactor `all_gather_anchor_positive_pairs` to use AllenNLP util for detecting distributed training setting.
- :white_check_mark: Add tests for `get_anchor_positive_pairs`.