### PR TITLE
Add contrastive loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For the time being, please install [AllenNLP](https://github.com/allenai/allennl
 If you want to train with [mixed-precision](https://devblogs.nvidia.com/mixed-precision-training-deep-neural-networks/) (strongly recommended if your GPU supports it), you will need to [install Apex with CUDA and C++ extensions](https://github.com/NVIDIA/apex#quick-start). Once installed, you need only to set `"opt_level"` to `"O1"` in your training [config](configs), or, equivalently, pass the following flag to `allennlp train`
 
 ```bash
---overrides '{"trainer.opt_level": "O1"}'
+--overrides "{'trainer.opt_level': 'O1'}"
 ```
 
 ## Usage
@@ -56,7 +56,7 @@ To train the model, run the following command
 ```bash
 allennlp train configs/contrastive.jsonnet \
     -s output \
-    -o '{"train_data_path": "path/to/input.txt"}' \
+    -o "{'train_data_path': 'path/to/input.txt'}" \
     --include-package t2t
 ```
 
@@ -69,7 +69,7 @@ To train on more than one GPU, provide a list of CUDA devices in your call to `a
 ```bash
 allennlp train configs/contrastive.jsonnet \
     -s output \
-    -o '{"train_data_path": "path/to/input.txt", "distributed.cuda_devices": [0, 1, 2, 3]}' \
+    -o "{'train_data_path': 'path/to/input.txt', 'distributed.cuda_devices': [0, 1, 2, 3]}" \
     --include-package t2t
 ```
 

--- a/t2t/losses/__init__.py
+++ b/t2t/losses/__init__.py
@@ -1,5 +1,6 @@
 from t2t.losses.pytorch_metric_learning import (
     CircleLoss,
+    ContrastiveLoss,
     CrossBatchMemory,
     MultiSimilarityLoss,
     NTXentLoss,

--- a/t2t/losses/pytorch_metric_learning.py
+++ b/t2t/losses/pytorch_metric_learning.py
@@ -14,7 +14,7 @@ class PyTorchMetricLearningLoss(Registrable):
     to the constructor the same arguments that the loss function does. See `NTXentLoss` below for an example.
     """
 
-    default_implementation = "nt_xent"
+    default_implementation = "contrastive"
 
     @classmethod
     def get_embeddings_and_labels(
@@ -72,6 +72,38 @@ class CircleLoss(PyTorchMetricLearningLoss, losses.CircleLoss):
         )
 
 
+@PyTorchMetricLearningLoss.register("contrastive")
+class ContrastiveLoss(PyTorchMetricLearningLoss, losses.ContrastiveLoss):
+    """Wraps the `ContrastiveLoss` implementation from Pytorch Metric Learning:
+    (https://kevinmusgrave.github.io/pytorch-metric-learning/losses/#contrastiveloss).
+
+    Registered as a `PyTorchMetricLearningLoss` with name "contrastive".
+    """
+
+    def __init__(
+        self,
+        pos_margin: int = 1,
+        neg_margin: int = 0,
+        use_similarity: bool = True,
+        power: int = 1,
+        avg_non_zero_only: bool = True,
+        normalize_embeddings: bool = True,
+        num_class_per_param: int = None,
+        learnable_param_names: List[str] = None,
+    ) -> None:
+
+        super().__init__(
+            pos_margin=pos_margin,
+            neg_margin=neg_margin,
+            use_similarity=use_similarity,
+            power=power,
+            avg_non_zero_only=avg_non_zero_only,
+            normalize_embeddings=normalize_embeddings,
+            num_class_per_param=num_class_per_param,
+            learnable_param_names=learnable_param_names,
+        )
+
+
 @PyTorchMetricLearningLoss.register("cross_batch_memory")
 class CrossBatchMemory(PyTorchMetricLearningLoss, losses.CrossBatchMemory):
     """Wraps the `CrossBatchMemory` implementation from Pytorch Metric Learning:
@@ -93,7 +125,7 @@ class CrossBatchMemory(PyTorchMetricLearningLoss, losses.CrossBatchMemory):
         )
 
 
-@PyTorchMetricLearningLoss.register("multi_sim_loss")
+@PyTorchMetricLearningLoss.register("multi_sim")
 class MultiSimilarityLoss(PyTorchMetricLearningLoss, losses.MultiSimilarityLoss):
     """Wraps the `MultiSimilarityLoss` implementation from Pytorch Metric Learning:
     (https://kevinmusgrave.github.io/pytorch-metric-learning/losses/#multisimilarityloss).

--- a/t2t/miners/pytorch_metric_learning.py
+++ b/t2t/miners/pytorch_metric_learning.py
@@ -60,7 +60,7 @@ class HDCMiner(PyTorchMetricLearningMiner, miners.HDCMiner):
         )
 
 
-@PyTorchMetricLearningMiner.register("multi_sim_miner")
+@PyTorchMetricLearningMiner.register("multi_sim")
 class MultiSimilarityMiner(PyTorchMetricLearningMiner, miners.MultiSimilarityMiner):
     """Wraps the `MultiSimilarityMiner` implementation from Pytorch Metric Learning:
     (https://kevinmusgrave.github.io/pytorch-metric-learning/miners/#multisimilarityminer).

--- a/t2t/models/contrastive_text_encoder.py
+++ b/t2t/models/contrastive_text_encoder.py
@@ -152,7 +152,7 @@ class ContrastiveTextEncoder(Model):
                     embedded_anchor_text, embedded_positive_text
                 )
                 indices_tuple = self._miner(embeddings, labels) if self._miner is not None else None
-                output_dict["loss"] += self._loss(embeddings, labels, indices_tuple=indices_tuple)
+                output_dict["loss"] += self._loss(embeddings, labels, indices_tuple)
             if anchor_masked_lm_loss is not None:
                 output_dict["loss"] += anchor_masked_lm_loss
 


### PR DESCRIPTION
# Overview

Adds a wrapper for the vanilla [contrastive loss](https://kevinmusgrave.github.io/pytorch-metric-learning/losses/#contrastiveloss). It also makes this the default loss (i.e. it will be used if no specific loss function `"type"` is specified in the config.

I added this because the [cross-batch memory](https://arxiv.org/abs/1912.06798) paper found that with a large enough queue size, it outperforms more complicated losses (like [multi-similarity](https://arxiv.org/abs/1904.06627)) so we should probably compare it to [NT-Xent loss](https://kevinmusgrave.github.io/pytorch-metric-learning/losses/#ntxentloss).

## Other changes

- :books: Flips the order of the single and double quotes in the readme examples which use AllenNLPs `--overrides` flag. This appears to be necessary if a user wants to specify these values with an environment variables (thanks @OsvaldN for discovering this).
- :recycle: Rename `"multi_sim_loss"` --> `"multi_sim"`, `"multi_sim_miner"` --> `"multi_sim"`
- :bug: Make `indices_tuple` a positional argument in the call to `self._loss`. This lets you pass the miner directly (via the constructor) or indirectly via the cross-batch memory loss.