### PR TITLE
Select sampling strategy

### DIFF
--- a/t2t/data/dataset_readers/dataset_utils/contrastive_utils.py
+++ b/t2t/data/dataset_readers/dataset_utils/contrastive_utils.py
@@ -1,13 +1,11 @@
-from enum import Enum
 from random import choice, randint
 from typing import Callable, List, Optional, Tuple
 
 import numpy as np
 
+from allennlp.common.logging import AllenNlpLogger
 
-class Strategy(str, Enum):
-    subsuming = "subsuming"
-    adjacent = "adjacent"
+logger = AllenNlpLogger(__name__)
 
 
 def sample_anchor_positives(
@@ -15,7 +13,7 @@ def sample_anchor_positives(
     max_span_len: int,
     min_span_len: int,
     num_spans: Optional[int] = 1,
-    strategy: Optional[Strategy] = None,
+    sampling_strategy: Optional[str] = None,
     tokenizer: Optional[Callable[[str], List[str]]] = None,
 ) -> Tuple[str, List[str]]:
     """Returns a tuple of anchor (`str`) and `num_spans` positive (`List[str]`) spans sampled from
@@ -31,22 +29,25 @@ def sample_anchor_positives(
         The minimum length of spans, after tokenization, to sample.
     num_spans : `int`, optional (default = 1)
         The number of spans to sample from `text` to serve as positive examples.
-    strategy : `Strategy`, optional (default = None)
-        One of "subsuming" or "adjacent". If "subsuming", positive spans are always subsumed by
-        the anchor. If "adjacent", positive spans are always adjacent to the anchor. If not
-        provided, positives may be subsumed, adjacent to, or overlapping with the anchor.
+    sampling_strategy : `str`, optional (default = None)
+        One of "subsuming" or "adjacent". If "subsuming," positive spans are always subsumed by the
+        anchor. If "adjacent", positive spans are always adjacent to the anchor. If not provided,
+        positives may be subsumed, adjacent to, or overlapping with the anchor. Has no effect if
+        `num_spans` is not provided.
     tokenizer : `Callable`, optional
         Optional tokenizer to use before sampling spans. If `None`, `text.split()` is used.
     """
     # Whitespace tokenization is much more straightforward (don't need to worry about chopping up
-    # subword tokens) but a user can also provide their own tokenization scheme if they want.
+    # subword tokens), but a user can also provide their own tokenization scheme if they want.
     tokens = tokenizer(text) if tokenizer is not None else text.split()
     num_tokens = len(tokens)
     tok_method = "tokenizer(text)" if tokenizer else "text.split()"
 
-    if num_tokens < 1:
+    # This is mostly arbitrary, but it prevents the Hypothesis tests from breaking. And it makes
+    # little sense to sample from extremely short documents.
+    if num_tokens < 10:
         raise ValueError(
-            (f"len({tok_method}) should be at least 1 (ideally much longer), got {num_tokens}.")
+            (f"len({tok_method}) should be at least 10 (ideally much longer), got {num_tokens}.")
         )
     if min_span_len > max_span_len:
         raise ValueError(
@@ -69,40 +70,50 @@ def sample_anchor_positives(
     anchor = " ".join(tokens[anchor_start:anchor_end])
 
     # Sample positives from around the anchor. The intuition being that text that appears close
-    # together is the same document is likely to be semantically similar. By default, these may be
-    # adjacent or overlap with each other and the anchor, but this can be selected manually with
-    # the `strategy` parameter. Their length is sampled from a beta distribution skewed towards
-    # shorter spans.
+    # together is the same document is likely to be semantically similar.
     positives = []
     for _ in range(num_spans):
+        # Their length is sampled from a beta distribution skewed towards shorter spans. The idea
+        # is to promote diversity and minimize the amount of overlapping text.
         positive_length = int(np.random.beta(2, 4) * (max_span_len - min_span_len) + min_span_len)
-        if strategy and strategy == strategy.subsuming:
+        # A user can specify a subsuming or adjacent only sampling strategy.
+        if sampling_strategy == "subsuming":
             positive_start = randint(anchor_start, anchor_end - positive_length)
-        elif strategy and strategy == strategy.adjacent:
-            # There are two types of adjacent positives, those that boarder the beginning of the
-            # anchor and those that border the end. These may not be valid in cases where the
-            # positive length is longer than the available space in the document.
+        elif sampling_strategy == "adjacent":
+            # We have to restrict positives to a length that will allow them to be adjacent to
+            # the anchor without running off the edge of the document. If documents are sufficiently
+            # long, this won't be a problem and the max_positive_length will equal max_span_len.
+            max_positive_len = min(max_span_len, max(anchor_start, num_tokens - anchor_end))
+            if positive_length > max_positive_len:
+                logger.warning_once(
+                    (
+                        f"There is no room to sample an adjacent positive span of"
+                        f" max_span_len {positive_length}. Temporarily reducing the"
+                        f" maximum span length of positives to {max_positive_len}."
+                        " This message will not be displayed again."
+                    )
+                )
+            positive_length = int(
+                np.random.beta(2, 4) * (max_positive_len - min_span_len) + min_span_len
+            )
+            # There are two types of adjacent positives, those that border the beginning of the
+            # anchor and those that border the end. The checks above guarantee at least one of these
+            # is valid.
             valid_starts = []
             if anchor_start - positive_length > 0:
                 valid_starts.append(anchor_start - positive_length)
             if anchor_end + positive_length <= num_tokens:
                 valid_starts.append(anchor_end)
-            if not valid_starts:
-                raise ValueError(
-                    (
-                        f"Cannot select adjacent only spans for a span length of {positive_length}"
-                        f" and a number of tokens len({tok_method}) ({num_tokens})."
-                    )
-                )
             positive_start = choice(valid_starts)
         else:
+            # By default, spans may be adjacent or overlap with each other and the anchor.
             # Be careful not to run off the edges of the document, as this error will pass silently.
             positive_start = randint(
                 max(0, anchor_start - positive_length),
                 min(anchor_end, num_tokens - positive_length),
             )
 
-    positive_end = positive_start + positive_length
-    positives.append(" ".join(tokens[positive_start:positive_end]))
+        positive_end = positive_start + positive_length
+        positives.append(" ".join(tokens[positive_start:positive_end]))
 
     return anchor, positives

--- a/t2t/data/dataset_readers/dataset_utils/contrastive_utils.py
+++ b/t2t/data/dataset_readers/dataset_utils/contrastive_utils.py
@@ -80,14 +80,14 @@ def sample_anchor_positives(
             positive_start = randint(anchor_start, anchor_end - positive_length)
         elif strategy and strategy == strategy.adjacent:
             # There are two types of adjacent positives, those that boarder the beginning of the
-            # anchor and those that boarder the end. These may not be valid in cases where the
+            # anchor and those that border the end. These may not be valid in cases where the
             # positive length is longer than the available space in the document.
             valid_starts = []
             if anchor_start - positive_length > 0:
                 valid_starts.append(anchor_start - positive_length)
-            elif anchor_end + positive_length <= num_tokens:
-                valid_starts.append(anchor_end + positive_length)
-            else:
+            if anchor_end + positive_length <= num_tokens:
+                valid_starts.append(anchor_end)
+            if not valid_starts:
                 raise ValueError(
                     (
                         f"Cannot select adjacent only spans for a span length of {positive_length}"

--- a/t2t/data/dataset_readers/dataset_utils/contrastive_utils.py
+++ b/t2t/data/dataset_readers/dataset_utils/contrastive_utils.py
@@ -1,7 +1,13 @@
-from random import randint
+from enum import Enum
+from random import choice, randint
 from typing import Callable, List, Optional, Tuple
 
 import numpy as np
+
+
+class Strategy(str, Enum):
+    subsuming = "subsuming"
+    adjacent = "adjacent"
 
 
 def sample_anchor_positives(
@@ -9,6 +15,7 @@ def sample_anchor_positives(
     max_span_len: int,
     min_span_len: int,
     num_spans: Optional[int] = 1,
+    strategy: Optional[Strategy] = None,
     tokenizer: Optional[Callable[[str], List[str]]] = None,
 ) -> Tuple[str, List[str]]:
     """Returns a tuple of anchor (`str`) and `num_spans` positive (`List[str]`) spans sampled from
@@ -24,6 +31,10 @@ def sample_anchor_positives(
         The minimum length of spans, after tokenization, to sample.
     num_spans : `int`, optional (default = 1)
         The number of spans to sample from `text` to serve as positive examples.
+    strategy : `Strategy`, optional (default = None)
+        One of "subsuming" or "adjacent". If "subsuming", positive spans are always subsumed by
+        the anchor. If "adjacent", positive spans are always adjacent to the anchor. If not
+        provided, positives may be subsumed, adjacent to, or overlapping with the anchor.
     tokenizer : `Callable`, optional
         Optional tokenizer to use before sampling spans. If `None`, `text.split()` is used.
     """
@@ -58,17 +69,40 @@ def sample_anchor_positives(
     anchor = " ".join(tokens[anchor_start:anchor_end])
 
     # Sample positives from around the anchor. The intuition being that text that appears close
-    # together is the same document is likely to be semantically similar. These may be adjacent or
-    # overlap with each other and the anchor. Their length is sampled from a beta distribution
-    # skewed towards shorter spans.
+    # together is the same document is likely to be semantically similar. By default, these may be
+    # adjacent or overlap with each other and the anchor, but this can be selected manually with
+    # the `strategy` parameter. Their length is sampled from a beta distribution skewed towards
+    # shorter spans.
     positives = []
     for _ in range(num_spans):
         positive_length = int(np.random.beta(2, 4) * (max_span_len - min_span_len) + min_span_len)
-        # Be careful not to run off the edges of the document, as this error will pass silently.
-        positive_start = randint(
-            max(0, anchor_start - positive_length), min(anchor_end, num_tokens - positive_length),
-        )
-        positive_end = positive_start + positive_length
-        positives.append(" ".join(tokens[positive_start:positive_end]))
+        if strategy and strategy == strategy.subsuming:
+            positive_start = randint(anchor_start, anchor_end - positive_length)
+        elif strategy and strategy == strategy.adjacent:
+            # There are two types of adjacent positives, those that boarder the beginning of the
+            # anchor and those that boarder the end. These may not be valid in cases where the
+            # positive length is longer than the available space in the document.
+            valid_starts = []
+            if anchor_start - positive_length > 0:
+                valid_starts.append(anchor_start - positive_length)
+            elif anchor_end + positive_length <= num_tokens:
+                valid_starts.append(anchor_end + positive_length)
+            else:
+                raise ValueError(
+                    (
+                        f"Cannot select adjacent only spans for a span length of {positive_length}"
+                        f" and a number of tokens len({tok_method}) ({num_tokens})."
+                    )
+                )
+            positive_start = choice(valid_starts)
+        else:
+            # Be careful not to run off the edges of the document, as this error will pass silently.
+            positive_start = randint(
+                max(0, anchor_start - positive_length),
+                min(anchor_end, num_tokens - positive_length),
+            )
+
+    positive_end = positive_start + positive_length
+    positives.append(" ".join(tokens[positive_start:positive_end]))
 
     return anchor, positives

--- a/t2t/models/contrastive_text_encoder.py
+++ b/t2t/models/contrastive_text_encoder.py
@@ -137,7 +137,6 @@ class ContrastiveTextEncoder(Model):
                 for chunk in chunk_positives(positives, chunk_dim=chunk_dim):
                     _, embedded_chunk = self._forward_internal(chunk)
                     embedded_positives.append(embedded_chunk)
-                # Stack and average across the same dim that we chunked on.
                 # Positives are represented by their mean embedding a la
                 # https://arxiv.org/abs/1902.09229.
                 embedded_positives = torch.stack(embedded_positives, dim=chunk_dim)
@@ -151,7 +150,7 @@ class ContrastiveTextEncoder(Model):
                     embedded_anchors, embedded_positives
                 )
                 # Get embeddings into the format that the PyTorch Metric Learning library expects
-                # before computing the loss (with an optional mining step)
+                # before computing the loss (with an optional mining step).
                 embeddings, labels = self._loss.get_embeddings_and_labels(
                     embedded_anchors, embedded_positives
                 )

--- a/t2t/models/contrastive_text_encoder_util.py
+++ b/t2t/models/contrastive_text_encoder_util.py
@@ -73,11 +73,11 @@ def all_gather_anchor_positive_pairs(
     positives_list = [torch.ones_like(positives) for _ in range(dist.get_world_size())]
     dist.all_gather(anchors_list, anchors)
     dist.all_gather(positives_list, positives)
-    # The gathered copy of the current replicas positive pairs have no gradients, so we overwrite them
-    # with the positive pairs generated on this replica, which DO have gradients back to the encoder.
+    # The gathered copy of the current replicas positive pairs have no gradients, so we overwrite
+    # them with the positive pairs generated on this replica, which DO have gradients.
     anchors_list[dist.get_rank()] = anchors
     positives_list[dist.get_rank()] = positives
-    # Finally, we concatenate the positive pairs so they can be fed to the contrastive loss
+    # Finally, we concatenate the positive pairs so they can be fed to the contrastive loss.
     anchors = torch.cat(anchors_list)
     positives = torch.cat(positives_list)
 

--- a/t2t/modules/text_field_embedders/mlm_text_field_embedder.py
+++ b/t2t/modules/text_field_embedders/mlm_text_field_embedder.py
@@ -16,9 +16,9 @@ class MLMTextFieldEmbedder(BasicTextFieldEmbedder):
     """
     This is a a simple wrapper around `BasicTextFieldEmbedder` that accounts for the fact that
     our custom PretrainedTransformerEmbedderMLM returns a tuple containing the loss for the masked
-    language modelling objective as well as some embedded text. I don't like that we had to modify this class
-    and hope in the future that we can replace it with a model from the https://github.com/allenai/allennlp-models
-    repo.
+    language modelling objective as well as some embedded text. I don't like that we had to modify
+    this class and hope in the future that we can replace it with a model from the
+    https://github.com/allenai/allennlp-models repo.
 
     Registered as a `TextFieldEmbedder` with name "mlm".
     """
@@ -55,8 +55,8 @@ class MLMTextFieldEmbedder(BasicTextFieldEmbedder):
 
             tensors: Dict[str, torch.Tensor] = text_field_input[key]
             if len(tensors) == 1 and len(missing_tensor_args) == 1:
-                # If there's only one tensor argument to the embedder, and we just have one tensor to
-                # embed, we can just pass in that tensor, without requiring a name match.
+                # If there's only one tensor argument to the embedder, and we just have one tensor
+                # to embed, we can just pass in that tensor, without requiring a name match.
                 masked_lm_loss, token_vectors = embedder(
                     list(tensors.values())[0], **forward_params_values
                 )

--- a/t2t/modules/token_embedders/pretrained_transformer_embedder_mlm.py
+++ b/t2t/modules/token_embedders/pretrained_transformer_embedder_mlm.py
@@ -12,9 +12,10 @@ from allennlp.modules.token_embedders.token_embedder import TokenEmbedder
 @TokenEmbedder.register("pretrained_transformer_mlm")
 class PretrainedTransformerEmbedderMLM(PretrainedTransformerEmbedder):
     """
-    This is a wrapper around `PretrainedTransformerEmbedder` that allows us to train against a masked language
-    modelling objective while we are embedding text. I don't like that we had to modify this class and hope in
-    the future that we can replace it with a model from the https://github.com/allenai/allennlp-models repo.
+    This is a wrapper around `PretrainedTransformerEmbedder` that allows us to train against a
+    masked language modelling objective while we are embedding text. I don't like that we had to
+    modify this class and hope in the future that we can replace it with a model from the
+    https://github.com/allenai/allennlp-models repo.
 
     Registered as a `TokenEmbedder` with name "pretrained_transformer_mlm".
     """
@@ -66,9 +67,10 @@ class PretrainedTransformerEmbedderMLM(PretrainedTransformerEmbedder):
         Shape: [batch_size, num_wordpieces, embedding_size].
         """
 
-        # Some of the huggingface transformers don't support type ids at all and crash when you supply them. For
-        # others, you can supply a tensor of zeros, and if you don't, they act as if you did. There is no practical
-        # difference to the caller, so here we pretend that one case is the same as another case.
+        # Some of the huggingface transformers don't support type ids at all and crash when you
+        # supply them. For others, you can supply a tensor of zeros, and if you don't, they act as
+        # if you did. There is no practical difference to the caller, so here we pretend that one
+        # case is the same as another case.
         if type_ids is not None:
             max_type_id = type_ids.max()
             if max_type_id == 0:
@@ -90,16 +92,17 @@ class PretrainedTransformerEmbedderMLM(PretrainedTransformerEmbedder):
         # or if self._max_length is not None:
         # [batch_size * num_segments, self._max_length, embedding_size]
 
-        # We call this with kwargs because some of the huggingface models don't have the token_type_ids parameter
-        # and fail even when it's given as None.
+        # We call this with kwargs because some of the huggingface models don't have the
+        # token_type_ids parameter and fail even when it's given as None.
         # Also, as of transformers v2.5.1, they are taking FloatTensor masks.
         parameters = {"input_ids": token_ids, "attention_mask": transformer_mask.float()}
         masked_lm_loss = None
         if type_ids is not None:
             parameters["token_type_ids"] = type_ids
         if self.masked_language_modeling:
-            # Even if masked_language_modeling is True, we may not be masked language modeling on the current
-            # batch. We still need to check if masked language modeling labels are present in the input.
+            # Even if masked_language_modeling is True, we may not be masked language modeling on
+            # the current batch. We still need to check if masked language modeling labels are
+            # present in the input.
             if masked_lm_labels is not None:
                 parameters["masked_lm_labels"] = masked_lm_labels
                 masked_lm_loss, _, hidden_states = self.transformer_model(**parameters)

--- a/t2t/tests/data/dataset_readers/dataset_utils/test_contrastive_utils.py
+++ b/t2t/tests/data/dataset_readers/dataset_utils/test_contrastive_utils.py
@@ -43,6 +43,7 @@ class TestContrastiveUtils:
                 num_spans=num_spans,
                 sampling_strategy=sampling_strategy,
             )
+            assert len(positives) == num_spans
             for anc, pos in zip_longest(anchor, positives, fillvalue=anchor):
                 anc_len, pos_len = len(self.tokenize(anc)), len(self.tokenize(pos))
 

--- a/t2t/tests/data/dataset_readers/dataset_utils/test_contrastive_utils.py
+++ b/t2t/tests/data/dataset_readers/dataset_utils/test_contrastive_utils.py
@@ -1,8 +1,10 @@
+from itertools import zip_longest
 from random import randint
+from typing import Union
 
 import pytest
 from hypothesis import given
-from hypothesis.strategies import text
+from hypothesis.strategies import integers, sampled_from, text
 
 from t2t.data.dataset_readers.dataset_utils.contrastive_utils import sample_anchor_positives
 
@@ -11,41 +13,61 @@ class TestContrastiveUtils:
     def tokenize(self, text):
         return text.split()
 
-    @given(text())
-    def test_sample_spans(self, text: str):
+    @given(
+        text=text(),
+        num_spans=integers(min_value=1, max_value=4),
+        sampling_strategy=sampled_from(["subsuming", "adjacent", None]),
+    )
+    def test_sample_spans(self, text: str, num_spans: int, sampling_strategy: Union[str, None]):
         num_tokens = len(self.tokenize(text))
+        # These represent sensible defaults
+        max_span_len = num_tokens // 2
+        min_span_len = randint(1, num_tokens // 2) if num_tokens // 2 > 1 else 1
 
-        # It doesn't make sense for either of these to be less than 1.
-        max_span_len = max(num_tokens // 2, 1)
-        min_span_len = max(int(0.25 * max_span_len), 1)
-        # Somewhat arbitrary but we want to know that the tests don't fail for num_spans > 1
-        num_spans = randint(1, 4)
-
-        # The sampling procedure will break if we don't have at least one token
-        if num_tokens < 1:
+        # The sampling procedure often breaks if we don't have at least ten tokens, so we set
+        # a strict lower bound.
+        if num_tokens < 10:
             with pytest.raises(ValueError):
                 _, _ = sample_anchor_positives(
-                    text, max_span_len=max_span_len, min_span_len=min_span_len, num_spans=num_spans
+                    text,
+                    max_span_len=max_span_len,
+                    min_span_len=min_span_len,
+                    num_spans=num_spans,
+                    sampling_strategy=sampling_strategy,
                 )
         else:
-            anchor, positives = sample_anchor_positives(text, max_span_len, min_span_len)
-            # Anchors and positives are sampled in nearly the same way, so just test them together
-            spans = [anchor] + positives
-            for span in spans:
-                span_len = len(self.tokenize(span))
+            anchor, positives = sample_anchor_positives(
+                text,
+                max_span_len=max_span_len,
+                min_span_len=min_span_len,
+                num_spans=num_spans,
+                sampling_strategy=sampling_strategy,
+            )
+            for anc, pos in zip_longest(anchor, positives, fillvalue=anchor):
+                anc_len, pos_len = len(self.tokenize(anc)), len(self.tokenize(pos))
 
-                assert span_len <= max_span_len
-                assert span_len >= min_span_len
+                # Do basic tests for both anchors and positives
+                assert anc_len <= max_span_len
+                assert anc_len >= min_span_len
+                assert pos_len <= max_span_len
+                assert pos_len >= min_span_len
                 # The tokenization process may lead to certain characters (such as escape
                 # characters) being dropped, so repeat the tokenization process before performing
                 # this check (otherwise a bunch of tests fail).
-                assert span in " ".join(self.tokenize(text))
+                assert anc in " ".join(self.tokenize(text))
+                assert pos in " ".join(self.tokenize(text))
+
+                # Test that specific sampling strategies are obeyed
+                if sampling_strategy == "subsuming":
+                    assert pos in " ".join(self.tokenize(anc))
+                elif sampling_strategy == "adjacent":
+                    assert pos not in " ".join(self.tokenize(anc))
 
     def test_sample_spans_raises_value_error_invalid_min_span_length(self):
         text = "They may take our lives, but they'll never take our freedom!"
         num_tokens = len(self.tokenize(text))
 
-        max_span_len = num_tokens // 2
+        max_span_len = num_tokens - 1  # This is guaranteed to be valid
         min_span_len = max_span_len + 1  # This is guaranteed to be invalid
 
         with pytest.raises(ValueError):
@@ -58,7 +80,7 @@ class TestContrastiveUtils:
         num_tokens = len(self.tokenize(text))
 
         max_span_len = num_tokens + 1  # This is guaranteed to be invalid
-        min_span_len = max_span_len // 2
+        min_span_len = max_span_len - 1  # This is guaranteed to be valid
 
         with pytest.raises(ValueError):
             _, _ = sample_anchor_positives(

--- a/t2t/tests/data/dataset_readers/test_contrastive_dataset_reader.py
+++ b/t2t/tests/data/dataset_readers/test_contrastive_dataset_reader.py
@@ -1,25 +1,63 @@
 import pytest
+from hypothesis import given, settings
+from hypothesis.strategies import integers, text
 
 from t2t.data.dataset_readers import ContrastiveDatasetReader
 
 
 class TestContrastiveDatasetReader:
-    def test_no_sample_context_manager(self):
-        # The value of these arguments are arbitrary, they just need to be > 0 so that
-        # ContrastiveDatasetReader.sample_spans is set to True.
-        dataset_reader = ContrastiveDatasetReader(num_spans=1, max_span_len=512, min_span_len=32)
+    # Not clear why turning off the deadline is neccesary? Errors out otherwise.
+    @settings(deadline=None)
+    @given(num_spans=integers(min_value=0, max_value=1))
+    def test_no_sample_context_manager(self, num_spans: int):
+        dataset_reader = ContrastiveDatasetReader(
+            num_spans=num_spans, max_span_len=32, min_span_len=16
+        )
 
         # While in the scope of the context manager, sample_spans should be false.
-        # After existing the context manger, it should return to True.
-        assert dataset_reader.sample_spans
+        # After existing the context manger, it should return to whatever value it was at
+        # before entering the contxt manager.
+        previous = dataset_reader.sample_spans
         with dataset_reader.no_sample():
             assert not dataset_reader.sample_spans
-        assert dataset_reader.sample_spans
+        assert dataset_reader.sample_spans == previous
 
-    def test_init_raises_value_error_no_max_min_span_length(self):
-        with pytest.raises(ValueError):
-            _ = ContrastiveDatasetReader(num_spans=1, max_span_len=None, min_span_len=32)
-        with pytest.raises(ValueError):
-            _ = ContrastiveDatasetReader(num_spans=1, max_span_len=512, min_span_len=None)
-        with pytest.raises(ValueError):
-            _ = ContrastiveDatasetReader(num_spans=1, max_span_len=None, min_span_len=None)
+    @given(
+        num_spans=integers(min_value=0, max_value=2),
+        max_span_len=integers(min_value=16, max_value=32),
+        min_span_len=integers(min_value=16, max_value=32),
+    )
+    def test_init_raises_value_error_no_max_min_span_length(
+        self, num_spans: int, max_span_len: int, min_span_len: int
+    ):
+        if num_spans:  # should only raise the error when num_spans is truthy
+            with pytest.raises(ValueError):
+                _ = ContrastiveDatasetReader(
+                    num_spans=num_spans, max_span_len=None, min_span_len=min_span_len
+                )
+            with pytest.raises(ValueError):
+                _ = ContrastiveDatasetReader(
+                    num_spans=num_spans, max_span_len=max_span_len, min_span_len=None
+                )
+            with pytest.raises(ValueError):
+                _ = ContrastiveDatasetReader(
+                    num_spans=num_spans, max_span_len=None, min_span_len=None
+                )
+
+    @given(
+        num_spans=integers(min_value=0, max_value=2),
+        max_span_len=integers(min_value=16, max_value=32),
+        min_span_len=integers(min_value=16, max_value=32),
+        sampling_strategy=text(),
+    )
+    def test_init_raises_value_error_invalid_sampling_strategy(
+        self, num_spans: int, max_span_len: int, min_span_len: int, sampling_strategy: str
+    ):
+        if num_spans:  # should only raise the error when num_spans is truthy
+            with pytest.raises(ValueError):
+                _ = ContrastiveDatasetReader(
+                    num_spans=num_spans,
+                    max_span_len=max_span_len,
+                    min_span_len=min_span_len,
+                    sampling_strategy=sampling_strategy,
+                )


### PR DESCRIPTION
# Overview

Provide a mechanism to select a sampling strategy. This can be selected in the config as `sampling_strategy` with choices `"subsuming"`, `"adjacent"` or `None` (which doesn't restrict sampling to either strategy).

## Other changes

- :white_check_mark: Add hypothesis generators to existing unit tests.