### PR TITLE
Use fast tokenizers

### DIFF
--- a/configs/contrastive.jsonnet
+++ b/configs/contrastive.jsonnet
@@ -26,6 +26,7 @@ local num_epochs = 1;
             "type": "pretrained_transformer",
             "model_name": transformer_model,
             "max_length": max_length,
+            "add_special_tokens": false
         },
         "token_indexers": {
             "tokens": {
@@ -47,11 +48,6 @@ local num_epochs = 1;
                 },
             },
         },
-        "seq2vec_encoder": {
-            "type": "bag_of_embeddings",
-            "embedding_dim": transformer_dim,
-            "averaged": true
-        },
         "loss": {
             "type": "nt_xent",
             "temperature": 0.0005,
@@ -59,8 +55,8 @@ local num_epochs = 1;
     },
     "data_loader": {
         "batch_size": 8,
-        // TODO (John): Currently, num_workers must be < 1 or we will end up loading the same data more than once.
-        // I need to modify the dataloader according to:
+        // TODO (John): Currently, num_workers must be < 1 or we will end up loading the same data
+        // more than once. I need to modify the dataloader according to:
         // https://pytorch.org/docs/stable/data.html#multi-process-data-loading
         // in order to support multi-processing.
         "num_workers": 1,
@@ -69,14 +65,14 @@ local num_epochs = 1;
         "batches_per_epoch": null
     },
     "trainer": {
-        // If you have installed Apex, you can chose one of its opt_levels here to use mixed precision training.
-        "opt_level": null,
+        // If Apex is installed, chose one of its opt_levels here to use mixed-precision training.
+        "opt_level": "O1",
         "optimizer": {
             "type": "huggingface_adamw",
             "lr": 5e-5,
             "weight_decay": 0.0,
             "parameter_groups": [
-                # Apply weight decay to pre-trained parameters, exlcuding LayerNorm parameters and biases
+                # Apply weight decay to pre-trained params, excluding LayerNorm params and biases
                 # See: https://github.com/huggingface/transformers/blob/2184f87003c18ad8a172ecab9a821626522cf8e7/examples/run_ner.py#L105
                 # Regex: https://regex101.com/r/ZUyDgR/3/tests
                 [["(?=.*transformer_model)(?=.*\\.+)(?!.*(LayerNorm|bias)).*$"], {"weight_decay": 0.1}],

--- a/configs/mlm_only.jsonnet
+++ b/configs/mlm_only.jsonnet
@@ -7,13 +7,18 @@ local transformer_dim = 768;
 local max_length = 512;
 local min_length = 32;
 
+local num_epochs = 1;
+
 {
+    "vocabulary": {
+        "type": "from_files",
+        // You must set this to the directory that contains the vocabulary.
+        // You can create this by passing the --dry-run flag to allennlp train
+        "directory": "datasets/openwebtext-570K/vocabulary"
+    },
     "dataset_reader": {
         "type": "contrastive",
         "lazy": true,
-        "num_spans": 2,
-        "max_span_len": max_length,
-        "min_span_len": min_length,
         "tokenizer": {
             "type": "pretrained_transformer",
             "model_name": transformer_model,
@@ -27,7 +32,7 @@ local min_length = 32;
             },
         },
     }, 
-    "train_data_path": null,
+    "train_data_path": "datasets/openwebtext-570K/train.txt",
     "model": {
         "type": "constrastive",
         "text_field_embedder": {
@@ -40,10 +45,6 @@ local min_length = 32;
                 },
             },
         },
-        "loss": {
-            "type": "nt_xent",
-            "temperature": 0.0005,
-        },
     },
     "data_loader": {
         "batch_size": 8,
@@ -53,10 +54,12 @@ local min_length = 32;
         // in order to support multi-processing.
         "num_workers": 1,
         "drop_last": true,
+        // This should be (# of instances in the train set)/(batch size)
+        "batches_per_epoch": null
     },
     "trainer": {
         // If Apex is installed, chose one of its opt_levels here to use mixed-precision training.
-        "opt_level": null,
+        "opt_level": "O1",
         "optimizer": {
             "type": "huggingface_adamw",
             "lr": 5e-5,
@@ -68,12 +71,18 @@ local min_length = 32;
                 [["(?=.*transformer_model)(?=.*\\.+)(?!.*(LayerNorm|bias)).*$"], {"weight_decay": 0.1}],
             ],
         },
-        "num_epochs": 1,
+        "num_epochs": num_epochs,
         "checkpointer": {
             // A value of null or -1 will save the weights of the model at the end of every epoch
             "num_serialized_models_to_keep": -1,
         },
         "cuda_device": 0,
         "grad_norm": 1.0,
+        "learning_rate_scheduler": {
+            "type": "slanted_triangular",
+            "num_epochs": num_epochs,
+            // This should be (# of instances in the train set)/(batch size)
+            "num_steps_per_epoch": null
+        },
     },
 }

--- a/configs/transformer_cls.jsonnet
+++ b/configs/transformer_cls.jsonnet
@@ -17,6 +17,7 @@ local cls_is_last_token = false;
             "type": "pretrained_transformer",
             "model_name": transformer_model,
             "max_length": max_length,
+            "add_special_tokens": false
         },
         "token_indexers": {
             "tokens": {
@@ -46,8 +47,8 @@ local cls_is_last_token = false;
     },
     "data_loader": {
         "batch_size": 8,
-        // TODO (John): Currently, num_workers must be < 1 or we will end up loading the same data more than once.
-        // I need to modify the dataloader according to:
+        // TODO (John): Currently, num_workers must be < 1 or we will end up loading the same data
+        // more than once. I need to modify the dataloader according to:
         // https://pytorch.org/docs/stable/data.html#multi-process-data-loading
         // in order to support multi-processing.
         "num_workers": 1,

--- a/configs/transformer_mean.jsonnet
+++ b/configs/transformer_mean.jsonnet
@@ -14,6 +14,7 @@ local max_length = 512;
             "type": "pretrained_transformer",
             "model_name": transformer_model,
             "max_length": max_length,
+            "add_special_tokens": false
         },
         "token_indexers": {
             "tokens": {
@@ -35,16 +36,11 @@ local max_length = 512;
                 },
             },
         },
-        "seq2vec_encoder": {
-            "type": "bag_of_embeddings",
-            "embedding_dim": transformer_dim,
-            "averaged": true
-        },
     },
     "data_loader": {
         "batch_size": 8,
-        // TODO (John): Currently, num_workers must be < 1 or we will end up loading the same data more than once.
-        // I need to modify the dataloader according to:
+        // TODO (John): Currently, num_workers must be < 1 or we will end up loading the same data
+        // more than once. I need to modify the dataloader according to:
         // https://pytorch.org/docs/stable/data.html#multi-process-data-loading
         // in order to support multi-processing.
         "num_workers": 1,

--- a/t2t/data/dataset_readers/dataset_utils/masked_lm_utils.py
+++ b/t2t/data/dataset_readers/dataset_utils/masked_lm_utils.py
@@ -23,8 +23,8 @@ def _mask_tokens(
         )
 
     labels = inputs.clone()
-    # We sample a few tokens in each sequence for masked-LM training (with probability args.mlm_probability
-    # defaults to 0.15 in Bert/RoBERTa)
+    # We sample a few tokens in each sequence for masked-LM training (with probability
+    # mlm_probability defaults to 0.15 in Bert/RoBERTa)
     probability_matrix = torch.full(labels.shape, mlm_probability)
     special_tokens_mask = [
         tokenizer.get_special_tokens_mask(val, already_has_special_tokens=True)
@@ -58,7 +58,11 @@ def mask_tokens(
     mlm_probability: float = 0.15,
 ) -> TextFieldTensors:
     device = tokens["tokens"]["token_ids"].device
-    inputs, labels = _mask_tokens(tokens["tokens"]["token_ids"].to("cpu"), tokenizer.tokenizer)
+    inputs, labels = _mask_tokens(
+        inputs=tokens["tokens"]["token_ids"].to("cpu"),
+        tokenizer=tokenizer.tokenizer,
+        mlm_probability=mlm_probability,
+    )
     tokens["tokens"]["token_ids"] = inputs.to(device)
     tokens["tokens"]["masked_lm_labels"] = labels.to(device)
     return tokens

--- a/t2t/modules/text_field_embedders/mlm_text_field_embedder.py
+++ b/t2t/modules/text_field_embedders/mlm_text_field_embedder.py
@@ -16,9 +16,10 @@ class MLMTextFieldEmbedder(BasicTextFieldEmbedder):
     """
     This is a a simple wrapper around `BasicTextFieldEmbedder` that accounts for the fact that
     our custom PretrainedTransformerEmbedderMLM returns a tuple containing the loss for the masked
-    language modelling objective as well as some embedded text. I don't like that we had to modify
-    this class and hope in the future that we can replace it with a model from the
-    https://github.com/allenai/allennlp-models repo.
+    language modelling objective as well as some embedded text.
+
+    I don't like that we had to modify this class and hope in the future that we can replace it
+    with a model from the https://github.com/allenai/allennlp-models repo.
 
     Registered as a `TextFieldEmbedder` with name "mlm".
     """
@@ -61,8 +62,8 @@ class MLMTextFieldEmbedder(BasicTextFieldEmbedder):
                     list(tensors.values())[0], **forward_params_values
                 )
             else:
-                # If there are multiple tensor arguments, we have to require matching names from the
-                # TokenIndexer.  I don't think there's an easy way around that.
+                # If there are multiple tensor arguments, we have to require matching names from
+                # the TokenIndexer. I don't think there's an easy way around that.
                 masked_lm_loss, token_vectors = embedder(**tensors, **forward_params_values)
             if token_vectors is not None:
                 # To handle some very rare use cases, we allow the return value of the embedder to

--- a/t2t/modules/token_embedders/pretrained_transformer_embedder_mlm.py
+++ b/t2t/modules/token_embedders/pretrained_transformer_embedder_mlm.py
@@ -27,7 +27,7 @@ class PretrainedTransformerEmbedderMLM(PretrainedTransformerEmbedder):
         self.masked_language_modeling = masked_language_modeling
         if self.masked_language_modeling:
             self.tokenizer = PretrainedTransformerTokenizer(model_name)
-            # Models with LM heads may NOT include hidden states in their outputs by default
+            # Models with LM heads may not include hidden states in their outputs by default.
             config = AutoConfig.from_pretrained(model_name, output_hidden_states=True)
             self.transformer_model = AutoModelWithLMHead.from_pretrained(model_name, config=config)
 

--- a/t2t/tests/fixtures/contrastive_text_encoder/common.jsonnet
+++ b/t2t/tests/fixtures/contrastive_text_encoder/common.jsonnet
@@ -18,6 +18,7 @@ local min_length = 32;
             "type": "pretrained_transformer",
             "model_name": transformer_model,
             "max_length": max_length,
+            "add_special_tokens": false
         },
         "token_indexers": {
             "tokens": {
@@ -30,22 +31,18 @@ local min_length = 32;
     "validation_data_path": "t2t/tests/fixtures/data/openwebtext/valid.txt",
     "model": {
         "type": "t2t.models.contrastive_text_encoder.ContrastiveTextEncoder",
-        "seq2vec_encoder": {
-            "type": "bag_of_embeddings",
-            "embedding_dim": transformer_dim,
-            "averaged": true
-        },
     },
     "data_loader": {
-        "batch_size": 5,
-        // TODO (John): Currently, num_workers must be < 1 or we will end up loading the same data more than once.
-        // I need to modify the dataloader according to:
+        "batch_size": 4,
+        // TODO (John): Currently, num_workers must be < 1 or we will end up loading the same data
+        // more than once. I need to modify the dataloader according to:
         // https://pytorch.org/docs/stable/data.html#multi-process-data-loading
         // in order to support multi-processing.
-        "num_workers": 1
+        "num_workers": 1,
+        "drop_last": true
     },
     "trainer": {
-        // If you have installed Apex, you can chose one of its opt_levels here to use mixed precision training.
+        // If Apex is installed, chose one of its opt_levels here to use mixed-precision training.
         "opt_level": null,
         "optimizer": {
             "type": "huggingface_adamw",

--- a/t2t/tests/fixtures/contrastive_text_encoder/experiment.jsonnet
+++ b/t2t/tests/fixtures/contrastive_text_encoder/experiment.jsonnet
@@ -18,7 +18,6 @@ local transformer_model = "distilroberta-base";
                 },
             },
         },
-        "seq2vec_encoder": COMMON['model']['seq2vec_encoder'],
         "loss": {
             "type": "t2t.losses.pytorch_metric_learning.NTXentLoss",
             "temperature": 0.001,

--- a/t2t/tests/fixtures/contrastive_text_encoder/experiment_contrastive_only.jsonnet
+++ b/t2t/tests/fixtures/contrastive_text_encoder/experiment_contrastive_only.jsonnet
@@ -18,7 +18,6 @@ local transformer_model = "distilroberta-base";
                 },
             },
         },
-        "seq2vec_encoder": COMMON['model']['seq2vec_encoder'],
         "loss": {
             "type": "t2t.losses.pytorch_metric_learning.NTXentLoss",
             "temperature": 0.001,

--- a/t2t/tests/fixtures/contrastive_text_encoder/experiment_feedforward.jsonnet
+++ b/t2t/tests/fixtures/contrastive_text_encoder/experiment_feedforward.jsonnet
@@ -18,11 +18,10 @@ local transformer_model = "distilroberta-base";
                 },
             },
         },
-        "seq2vec_encoder": COMMON['model']['seq2vec_encoder'],
         "feedforward": {
             "input_dim": 768,
             "num_layers": 1,
-            "hidden_dims": [16],
+            "hidden_dims": 16,
             "activations": "relu",
         },
         "loss": {

--- a/t2t/tests/fixtures/contrastive_text_encoder/experiment_mlm_only.jsonnet
+++ b/t2t/tests/fixtures/contrastive_text_encoder/experiment_mlm_only.jsonnet
@@ -18,7 +18,6 @@ local transformer_model = "distilroberta-base";
                 },
             },
         },
-        "seq2vec_encoder": COMMON['model']['seq2vec_encoder'],
         "loss": null
     },
     "data_loader": COMMON['data_loader'],

--- a/t2t/tests/models/test_contrastive_text_encoder.py
+++ b/t2t/tests/models/test_contrastive_text_encoder.py
@@ -8,8 +8,8 @@ from allennlp.models import Model
 
 
 class TestContrastiveTextEncoder(ModelTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.FIXTURES_ROOT = Path(
             "t2t/tests/fixtures"  # We need to override the path set by AllenNLP
         )


### PR DESCRIPTION
# Overview

Makes a tiny tweak that allows us to use the new fast Tokenizers library (this _may_ make training _slightly_ faster as we tokenize online). This assumes you have installed the latest release candidate from AllenNLP.

## Other changes

- ♻️ Set the default seq2vec pooler as a means BOW encoder -- user no longer needs to specify.
- :bug: Fix bug where `mlm_probability` in mask tokens was ignored.

## TODO

The tests are still breaking in the GitHub CI, but they pass locally, so ignoring for now.
